### PR TITLE
Pokestops anchorpoint

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -141,7 +141,7 @@
                                 Command="{Binding TrySearchPokestop, Source={Binding GameManagerViewModel, Source={StaticResource Locator}}}">
                             <Image Source="{Binding CooldownCompleteTimestampMs, Converter={StaticResource PokestopToIconConverter}}"
                                    maps:MapControl.Location="{Binding Converter={StaticResource MapObjectToGeopointConverter}, ConverterParameter=pokestop}"
-                                   maps:MapControl.NormalizedAnchorPoint="0,1"
+                                   maps:MapControl.NormalizedAnchorPoint="0.5,1"
                                    Stretch="Uniform"
                                    Height="64"
                                    Width="64" />


### PR DESCRIPTION
This change will correct the Pokestops anchorpoints and they will no longer 'float' across the map.