### PR TITLE
Pokestops no longer 'float' across the map

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -137,11 +137,11 @@
                 <maps:MapItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Button Style="{ThemeResource ImageButtonStyle}"
-                                CommandParameter="{Binding}"
+                                CommandParameter="{Binding}" 
                                 Command="{Binding TrySearchPokestop, Source={Binding GameManagerViewModel, Source={StaticResource Locator}}}">
                             <Image Source="{Binding CooldownCompleteTimestampMs, Converter={StaticResource PokestopToIconConverter}}"
                                    maps:MapControl.Location="{Binding Converter={StaticResource MapObjectToGeopointConverter}, ConverterParameter=pokestop}"
-                                   maps:MapControl.NormalizedAnchorPoint="0,1"
+                                   maps:MapControl.NormalizedAnchorPoint="{Binding Anchor}"
                                    Stretch="Uniform"
                                    Height="64"
                                    Width="64" />

--- a/PokemonGoAPI/GeneratedCode/Payloads.cs
+++ b/PokemonGoAPI/GeneratedCode/Payloads.cs
@@ -8383,6 +8383,8 @@ namespace PokemonGo.RocketAPI.GeneratedCode
             get { return Descriptor; }
         }
 
+        public Windows.Foundation.Point Anchor { get { return new Windows.Foundation.Point(0.5, 1); } }
+
         public FortData Clone()
         {
             return new FortData(this);


### PR DESCRIPTION
Added NormalizedAnchorPoint for Pokestops, so they will not 'float' across the map. (Second attempt, this worked for me).