### PR TITLE
Hidden botton NavigationBar on start

### DIFF
--- a/PokemonGo-UWP/App.xaml.cs
+++ b/PokemonGo-UWP/App.xaml.cs
@@ -56,6 +56,10 @@ namespace PokemonGo_UWP
                 var statusBar = StatusBar.GetForCurrentView();
                 await statusBar.HideAsync();
             }
+
+            // Enter into full screen mode
+            Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
+
             await Task.CompletedTask;
         }
 


### PR DESCRIPTION
Application will start now in full screen mode, but user can still open bottom navigation bar.