### PR TITLE
Update .NETCore NuGet from 5.1.0 to 5.2.2

### DIFF
--- a/Google.Protobuf/project.json
+++ b/Google.Protobuf/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {
     "uap10.0": {}

--- a/PokemonGo-UWP/project.json
+++ b/PokemonGo-UWP/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "HockeySDK.UWP": "4.1.3",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "Octokit": "0.21.1",
     "Template10": "1.1.12-preview-160712",

--- a/PokemonGoAPI/project.json
+++ b/PokemonGoAPI/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.AspNet.WebApi.Client": "5.2.3",
     "Microsoft.Net.Http": "2.2.29",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "PCLWebUtility": "1.0.3",
     "S2Geometry": "1.0.3"


### PR DESCRIPTION
I wasn't able to build clean cloned repo without this update.
For me to get this working properly I figured out, that after nuget update, I had to remove folders bin and obj from all projects and also files project.lock.json. (Rebuild in VS didn't work for me)

After that I am now able build, deploy and run on every platform properly. (desktop/arm)

However I would strongly advise to test this before merging. Because I am running Preview build of Windows 10 14393.5 with newest Win10SDK, which should be hopefully production ready tomorrow as Anniversary update, but I don't know...