### PR TITLE
Disabled map scrolling, a part of #231

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -119,6 +119,8 @@
                          TiltInteractionMode="GestureAndControl"
                          MapServiceToken="{x:Bind ViewModel.MapServiceToken, Mode=OneTime}"    
                          Canvas.ZIndex="1"
+                         PanInteractionMode="Disabled"
+                         ZoomInteractionMode="GestureOnly"
                          x:Name="GameMapControl">
             
             <Image Source="../Assets/UI/ash.png"                   


### PR DESCRIPTION
With this it's more like the original niantic app. It's less bouncy and annoying while walking, you can rotate, and pitch with two finger (default Mapcontrol) gestures.