### PR TITLE
Fixed wrong displaying of experience

### DIFF
--- a/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
@@ -45,7 +45,8 @@ namespace PokemonGo_UWP.ViewModels
             if (parameter is bool)
             {
                 // First time navigating here, we need to initialize data updating but only if we have GPS access
-                await Dispatcher.DispatchAsync(async () => { 
+                await Dispatcher.DispatchAsync(async () =>
+                {
                     var accessStatus = await Geolocator.RequestAccessAsync();
                     switch (accessStatus)
                     {
@@ -63,8 +64,8 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state                
-                PlayerProfile = (PlayerData) suspensionState[nameof(PlayerProfile)];
-                PlayerStats = (PlayerStats) suspensionState[nameof(PlayerStats)];                
+                PlayerProfile = (PlayerData)suspensionState[nameof(PlayerProfile)];
+                PlayerStats = (PlayerStats)suspensionState[nameof(PlayerStats)];
             }
             else
             {
@@ -77,6 +78,7 @@ namespace PokemonGo_UWP.ViewModels
                     // TODO: report level increase
                 }
                 PlayerStats = tmpStats;
+                RaisePropertyChanged(nameof(ExperienceValue));
             }
             await Task.CompletedTask;
         }
@@ -161,6 +163,9 @@ namespace PokemonGo_UWP.ViewModels
             get { return _playerStats; }
             set { Set(ref _playerStats, value); }
         }
+
+        public int ExperienceValue => _playerStats == null ? 0 : (int)(((double)_playerStats.Experience - _playerStats.PrevLevelXp) /
+            (_playerStats.NextLevelXp - _playerStats.PrevLevelXp) * 100);
 
         public InventoryDelta InventoryDelta
         {

--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -343,8 +343,7 @@
                     </Ellipse.Fill>
                 </Ellipse>
 
-                <ProgressBar Value="{Binding PlayerStats.Experience}"
-                             Maximum="{Binding PlayerStats.NextLevelXp}"
+                <ProgressBar Value="{Binding ExperienceValue}"
                              Foreground="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
                              Height="5"
                              Margin="0,-5,0,0"


### PR DESCRIPTION
I also noticed (like in issue #297) that the experience bar was not displayed correctly. The reason is that the maximum of the progressbar was set to the **full amount** of experience that was needed for the next level.

My first approach was to set the minimum value to the amount of experience from the previous level, but than the progressbar would be filled all the time. Now I calculated a value between 0 and 100 that represents the right percentage value.