### PR TITLE
[ja-JP] Pokemon Translate 

### DIFF
--- a/PokemonGo-UWP/Strings/ja-JP/Pokemon.resw
+++ b/PokemonGo-UWP/Strings/ja-JP/Pokemon.resw
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Abra" xml:space="preserve">
+    <value>ケーシィ</value>
+  </data>
+  <data name="Aerodactyl" xml:space="preserve">
+    <value>プテラ</value>
+  </data>
+  <data name="Alakazam" xml:space="preserve">
+    <value>フーディン</value>
+  </data>
+  <data name="Arbok" xml:space="preserve">
+    <value>アーボック</value>
+  </data>
+  <data name="Arcanine" xml:space="preserve">
+    <value>リザード</value>
+  </data>
+  <data name="Articuno" xml:space="preserve">
+    <value>ウインディ</value>
+  </data>
+  <data name="Beedrill" xml:space="preserve">
+    <value>スピアー</value>
+  </data>
+  <data name="Bellsprout" xml:space="preserve">
+    <value>マダツボミ</value>
+  </data>
+  <data name="Blastoise" xml:space="preserve">
+    <value>カメックス</value>
+  </data>
+  <data name="Bulbasaur" xml:space="preserve">
+    <value>フシギダネ</value>
+  </data>
+  <data name="Butterfree" xml:space="preserve">
+    <value>バタフリー</value>
+  </data>
+  <data name="Caterpie" xml:space="preserve">
+    <value>キャタピー</value>
+  </data>
+  <data name="Chansey" xml:space="preserve">
+    <value>ラッキー</value>
+  </data>
+  <data name="Charizard" xml:space="preserve">
+    <value>リザードン</value>
+  </data>
+  <data name="Charmander" xml:space="preserve">
+    <value>ヒトカゲ</value>
+  </data>
+  <data name="Charmeleon" xml:space="preserve">
+    <value>リザード</value>
+  </data>
+  <data name="Clefable" xml:space="preserve">
+    <value>ピクシー</value>
+  </data>
+  <data name="Clefairy" xml:space="preserve">
+    <value>ピッピ</value>
+  </data>
+  <data name="Cloyster" xml:space="preserve">
+    <value>パルシェン</value>
+  </data>
+  <data name="Cubone" xml:space="preserve">
+    <value>カラカラ</value>
+  </data>
+  <data name="Dewgong" xml:space="preserve">
+    <value>ジュゴン</value>
+  </data>
+  <data name="Diglett" xml:space="preserve">
+    <value>ディグダ</value>
+  </data>
+  <data name="Ditto" xml:space="preserve">
+    <value>メタモン</value>
+  </data>
+  <data name="Dodrio" xml:space="preserve">
+    <value>ドードリオ</value>
+  </data>
+  <data name="Doduo" xml:space="preserve">
+    <value>ドードー</value>
+  </data>
+  <data name="Dragonair" xml:space="preserve">
+    <value>ハクリュー</value>
+  </data>
+  <data name="Dragonite" xml:space="preserve">
+    <value>カイリｭウ</value>
+  </data>
+  <data name="Dratini" xml:space="preserve">
+    <value>ミニリｭウ</value>
+  </data>
+  <data name="Drowzee" xml:space="preserve">
+    <value>スリープ</value>
+  </data>
+  <data name="Dugtrio" xml:space="preserve">
+    <value>ダグトリオ</value>
+  </data>
+  <data name="Eevee" xml:space="preserve">
+    <value>イーブイ</value>
+  </data>
+  <data name="Ekans" xml:space="preserve">
+    <value>アーボ</value>
+  </data>
+  <data name="Electabuzz" xml:space="preserve">
+    <value>エレブー</value>
+  </data>
+  <data name="Electrode" xml:space="preserve">
+    <value>マルマイン</value>
+  </data>
+  <data name="Exeggcute" xml:space="preserve">
+    <value>タマタマ</value>
+  </data>
+  <data name="Exeggutor" xml:space="preserve">
+    <value>ナッシー</value>
+  </data>
+  <data name="Farfetchd" xml:space="preserve">
+    <value>カモネギ</value>
+  </data>
+  <data name="Fearow" xml:space="preserve">
+    <value>オニドリル</value>
+  </data>
+  <data name="Flareon" xml:space="preserve">
+    <value>ブースター</value>
+  </data>
+  <data name="Gastly" xml:space="preserve">
+    <value>ゴース</value>
+  </data>
+  <data name="Gengar" xml:space="preserve">
+    <value>ゲンガー</value>
+  </data>
+  <data name="Geodude" xml:space="preserve">
+    <value>イシツブテ</value>
+  </data>
+  <data name="Gloom" xml:space="preserve">
+    <value>クサイハナ</value>
+  </data>
+  <data name="Golbat" xml:space="preserve">
+    <value>ゴルバット</value>
+  </data>
+  <data name="Goldeen" xml:space="preserve">
+    <value>トサキント</value>
+  </data>
+  <data name="Golduck" xml:space="preserve">
+    <value>ゴルダック</value>
+  </data>
+  <data name="Golem" xml:space="preserve">
+    <value>ゴローニャ</value>
+  </data>
+  <data name="Graveler" xml:space="preserve">
+    <value>ゴローン</value>
+  </data>
+  <data name="Grimer" xml:space="preserve">
+    <value>ベトベター</value>
+  </data>
+  <data name="Growlithe" xml:space="preserve">
+    <value>ガーディ</value>
+  </data>
+  <data name="Gyarados" xml:space="preserve">
+    <value>ギャラドス</value>
+  </data>
+  <data name="Haunter" xml:space="preserve">
+    <value>ゴースト</value>
+  </data>
+  <data name="Hitmonchan" xml:space="preserve">
+    <value>エビワラー</value>
+  </data>
+  <data name="Hitmonlee" xml:space="preserve">
+    <value>サワムラー</value>
+  </data>
+  <data name="Horsea" xml:space="preserve">
+    <value>タッツー</value>
+  </data>
+  <data name="Hypno" xml:space="preserve">
+    <value>スリーパー</value>
+  </data>
+  <data name="Ivysaur" xml:space="preserve">
+    <value>フシギソウ</value>
+  </data>
+  <data name="Jigglypuff" xml:space="preserve">
+    <value>プリン</value>
+  </data>
+  <data name="Jolteon" xml:space="preserve">
+    <value>サンダース</value>
+  </data>
+  <data name="Jynx" xml:space="preserve">
+    <value>ルージュラ</value>
+  </data>
+  <data name="Kabuto" xml:space="preserve">
+    <value>カブト</value>
+  </data>
+  <data name="Kabutops" xml:space="preserve">
+    <value>カブトプス</value>
+  </data>
+  <data name="Kadabra" xml:space="preserve">
+    <value>ユンゲラー</value>
+  </data>
+  <data name="Kakuna" xml:space="preserve">
+    <value>コクーン</value>
+  </data>
+  <data name="Kangaskhan" xml:space="preserve">
+    <value>ガルーラ</value>
+  </data>
+  <data name="Kingler" xml:space="preserve">
+    <value>キングラー</value>
+  </data>
+  <data name="Koffing" xml:space="preserve">
+    <value>ドガース</value>
+  </data>
+  <data name="Krabby" xml:space="preserve">
+    <value>ドガース</value>
+  </data>
+  <data name="Lapras" xml:space="preserve">
+    <value>ラプラス</value>
+  </data>
+  <data name="Lickitung" xml:space="preserve">
+    <value>ベロリンガ</value>
+  </data>
+  <data name="Machamp" xml:space="preserve">
+    <value>カイリキー</value>
+  </data>
+  <data name="Machoke" xml:space="preserve">
+    <value>ゴーリキー</value>
+  </data>
+  <data name="Machop" xml:space="preserve">
+    <value>ワンリキー</value>
+  </data>
+  <data name="Magikarp" xml:space="preserve">
+    <value>コイキング</value>
+  </data>
+  <data name="Magmar" xml:space="preserve">
+    <value>ブーバー</value>
+  </data>
+  <data name="Magnemite" xml:space="preserve">
+    <value>コイル</value>
+  </data>
+  <data name="Magneton" xml:space="preserve">
+    <value>レアコイル</value>
+  </data>
+  <data name="Mankey" xml:space="preserve">
+    <value>マンキー</value>
+  </data>
+  <data name="Marowak" xml:space="preserve">
+    <value>ガラガラ</value>
+  </data>
+  <data name="Meowth" xml:space="preserve">
+    <value>ニャース</value>
+  </data>
+  <data name="Metapod" xml:space="preserve">
+    <value>トランセル</value>
+  </data>
+  <data name="Mew" xml:space="preserve">
+    <value>ミｭウ</value>
+  </data>
+  <data name="Mewtwo" xml:space="preserve">
+    <value>ミｭウツ</value>
+  </data>
+  <data name="Missingno" xml:space="preserve">
+    <value>けつばん</value>
+  </data>
+  <data name="Moltres" xml:space="preserve">
+    <value>ファイヤー</value>
+  </data>
+  <data name="MrMime" xml:space="preserve">
+    <value>バリヤード</value>
+  </data>
+  <data name="Muk" xml:space="preserve">
+    <value>ベトベトン</value>
+  </data>
+  <data name="Nidoking" xml:space="preserve">
+    <value>ニドキング</value>
+  </data>
+  <data name="Nidoqueen" xml:space="preserve">
+    <value>ニドクイン</value>
+  </data>
+  <data name="NidoranFemale" xml:space="preserve">
+    <value>ニドクイン F</value>
+  </data>
+  <data name="NidoranMale" xml:space="preserve">
+    <value>ニドラン M</value>
+  </data>
+  <data name="Nidorina" xml:space="preserve">
+    <value>ニドリーナ</value>
+  </data>
+  <data name="Nidorino" xml:space="preserve">
+    <value>ニドリーノ</value>
+  </data>
+  <data name="Ninetales" xml:space="preserve">
+    <value>キｭウコン</value>
+  </data>
+  <data name="Oddish" xml:space="preserve">
+    <value>ナゾノクサ</value>
+  </data>
+  <data name="Omanyte" xml:space="preserve">
+    <value>オムナイト</value>
+  </data>
+  <data name="Omastar" xml:space="preserve">
+    <value>オムスター</value>
+  </data>
+  <data name="Onix" xml:space="preserve">
+    <value>イワーク</value>
+  </data>
+  <data name="Paras" xml:space="preserve">
+    <value>パラス</value>
+  </data>
+  <data name="Parasect" xml:space="preserve">
+    <value>パラセクト</value>
+  </data>
+  <data name="Persian" xml:space="preserve">
+    <value>ペルシアン</value>
+  </data>
+  <data name="Pidgeot" xml:space="preserve">
+    <value>ピジョット</value>
+  </data>
+  <data name="Pidgeotto" xml:space="preserve">
+    <value>ピジョン</value>
+  </data>
+  <data name="Pidgey" xml:space="preserve">
+    <value>ポッポ</value>
+  </data>
+  <data name="Pikachu" xml:space="preserve">
+    <value>ピカチュウ</value>
+  </data>
+  <data name="Pinsir" xml:space="preserve">
+    <value>カイロス</value>
+  </data>
+  <data name="Poliwag" xml:space="preserve">
+    <value>ニョロモ</value>
+  </data>
+  <data name="Poliwhirl" xml:space="preserve">
+    <value>ニョロゾ</value>
+  </data>
+  <data name="Poliwrath" xml:space="preserve">
+    <value>ニョロボン</value>
+  </data>
+  <data name="Ponyta" xml:space="preserve">
+    <value>ポニータ</value>
+  </data>
+  <data name="Porygon" xml:space="preserve">
+    <value>ポリゴン</value>
+  </data>
+  <data name="Primeape" xml:space="preserve">
+    <value>オコリザル</value>
+  </data>
+  <data name="Psyduck" xml:space="preserve">
+    <value>コダック</value>
+  </data>
+  <data name="Raichu" xml:space="preserve">
+    <value>ライチュウ</value>
+  </data>
+  <data name="Rapidash" xml:space="preserve">
+    <value>ギャロップ</value>
+  </data>
+  <data name="Raticate" xml:space="preserve">
+    <value>ラッタ</value>
+  </data>
+  <data name="Rattata" xml:space="preserve">
+    <value>コラッタ</value>
+  </data>
+  <data name="Rhydon" xml:space="preserve">
+    <value>サイドン</value>
+  </data>
+  <data name="Rhyhorn" xml:space="preserve">
+    <value>サイホーン</value>
+  </data>
+  <data name="Sandshrew" xml:space="preserve">
+    <value>サンド</value>
+  </data>
+  <data name="Sandslash" xml:space="preserve">
+    <value>サンドパン</value>
+  </data>
+  <data name="Scyther" xml:space="preserve">
+    <value>ストライク</value>
+  </data>
+  <data name="Seadra" xml:space="preserve">
+    <value>シードラ</value>
+  </data>
+  <data name="Seaking" xml:space="preserve">
+    <value>アズマオウ</value>
+  </data>
+  <data name="Seel" xml:space="preserve">
+    <value>パウワウ</value>
+  </data>
+  <data name="Shellder" xml:space="preserve">
+    <value>シェルダー</value>
+  </data>
+  <data name="Slowbro" xml:space="preserve">
+    <value>ヤドラン</value>
+  </data>
+  <data name="Slowpoke" xml:space="preserve">
+    <value>ヤドン</value>
+  </data>
+  <data name="Snorlax" xml:space="preserve">
+    <value>カビゴン</value>
+  </data>
+  <data name="Spearow" xml:space="preserve">
+    <value>オニスズメ</value>
+  </data>
+  <data name="Squirtle" xml:space="preserve">
+    <value>ゼニガメ</value>
+  </data>
+  <data name="Starmie" xml:space="preserve">
+    <value>スターミー</value>
+  </data>
+  <data name="Staryu" xml:space="preserve">
+    <value>ヒトデマン</value>
+  </data>
+  <data name="Tangela" xml:space="preserve">
+    <value>モンジャラ</value>
+  </data>
+  <data name="Tauros" xml:space="preserve">
+    <value>ケンタロス</value>
+  </data>
+  <data name="Tentacool" xml:space="preserve">
+    <value>メノクラゲ</value>
+  </data>
+  <data name="Tentacruel" xml:space="preserve">
+    <value>ドククラゲ</value>
+  </data>
+  <data name="Vaporeon" xml:space="preserve">
+    <value>シャワーズ</value>
+  </data>
+  <data name="Venomoth" xml:space="preserve">
+    <value>モルフォン</value>
+  </data>
+  <data name="Venonat" xml:space="preserve">
+    <value>コンパン</value>
+  </data>
+  <data name="Venusaur" xml:space="preserve">
+    <value>フシギバナ</value>
+  </data>
+  <data name="Victreebel" xml:space="preserve">
+    <value>ウツボット</value>
+  </data>
+  <data name="Vileplume" xml:space="preserve">
+    <value>ラフレシア</value>
+  </data>
+  <data name="Voltorb" xml:space="preserve">
+    <value>ビリリダマ</value>
+  </data>
+  <data name="Vulpix" xml:space="preserve">
+    <value>ロコン</value>
+  </data>
+  <data name="Wartortle" xml:space="preserve">
+    <value>カメール</value>
+  </data>
+  <data name="Weedle" xml:space="preserve">
+    <value>ビードル</value>
+  </data>
+  <data name="Weepinbell" xml:space="preserve">
+    <value>ウツドン</value>
+  </data>
+  <data name="Weezing" xml:space="preserve">
+    <value>マタドガス</value>
+  </data>
+  <data name="Wigglytuff" xml:space="preserve">
+    <value>プクリン </value>
+  </data>
+  <data name="Zapdos" xml:space="preserve">
+    <value>サンダー</value>
+  </data>
+  <data name="Zubat" xml:space="preserve">
+    <value>ズバット</value>
+  </data>
+</root>


### PR DESCRIPTION
Added:

1. ja-JP Pokemon Names.

Fixed:

Nothing.