### PR TITLE
Fixed getting "Updates" folder

### DIFF
--- a/PokemonGo-UWP/Utils/UpdateManager.cs
+++ b/PokemonGo-UWP/Utils/UpdateManager.cs
@@ -221,16 +221,7 @@ namespace PokemonGo_UWP.Utils
         private static async Task<StorageFolder> GetTemporaryUpdateFolderAsync()
         {
             StorageFolder temp = ApplicationData.Current.TemporaryFolder;
-            StorageFolder folder = null;
-            try
-            {
-                folder = await temp.GetFolderAsync("Updates");
-            }
-            catch(FileNotFoundException)
-            {
-                folder = await temp.CreateFolderAsync("Updates");
-
-            }
+            StorageFolder folder = await temp.CreateFolderAsync("Updates", CreationCollisionOption.OpenIfExists);
 
             return folder;
         }


### PR DESCRIPTION
Currently, there will be thrown an IOException, if the "Updates" Folder is not available. Then it will be create.
With the new Change, the "updates" Folder will be created, but if it exists, it will be opened.