### PR TITLE
Automatically close the pokemon SortMenuPanel when a sorting is selected

### DIFF
--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -114,9 +114,17 @@
 
             <ListView ItemsSource="{Binding Converter={StaticResource PokemonSortingModesToSortingModesListConverter}}"
                       SelectedItem="{Binding CurrentPokemonSortingMode, Mode=TwoWay}"
+                      IsItemClickEnabled="True"
                       RelativePanel.Above="CloseSortMenuButton"
                       RelativePanel.AlignRightWithPanel="True">
 
+                <interactivity:Interaction.Behaviors>
+                    <core:EventTriggerBehavior EventName="ItemClick">
+                        <core:CallMethodAction MethodName="Begin"
+                                               TargetObject="{Binding ElementName=HideSortMenuStoryboard}" />
+                    </core:EventTriggerBehavior>
+                </interactivity:Interaction.Behaviors>
+                
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="HorizontalContentAlignment" Value="Stretch" />


### PR DESCRIPTION
This mimics the behavior of the official app.

I have simply reused the hide storyboard on every item click. Since there are no disabled items this should suffice.