### PR TITLE
Pokesort settings

### DIFF
--- a/PokemonGo-UWP/Utils/SettingsService.cs
+++ b/PokemonGo-UWP/Utils/SettingsService.cs
@@ -54,6 +54,12 @@ namespace PokemonGo_UWP.Utils
             set { _helper.Write(nameof(IsAutoRotateMapEnabled), value); }
         }
 
+        public PokemonSortingModes PokemonSortingMode
+        {
+            get { return this._helper.Read(nameof(PokemonSortingMode), PokemonSortingModes.Combat); }
+            set { this._helper.Write(nameof(PokemonSortingMode), value); }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
im using the PokemonSortingMode setting directly as a backing field because i found no reason to complicate this

since there is no implicity set on the CurrentPokemonSortingMode property on initialization, the UpdateSorting method will not fire then

explicitly calling updatesorting would make the list flash when the list is opened

that is why the sortingmode application is factored out into an other method and list is initialized with the correct order of elements