### PR TITLE
Prevent exceptions thrown from async void methods from bringing down the application

### DIFF
--- a/PokemonGo-UWP/PokemonGo-UWP.csproj
+++ b/PokemonGo-UWP/PokemonGo-UWP.csproj
@@ -407,8 +407,9 @@
     <Compile Include="Utils\Achievement\BadgeTypeAttribute.cs" />
     <Compile Include="Utils\Achievement\SilverAttribute.cs" />
     <Compile Include="Utils\Achievement\GoldAttribute.cs" />
-    <Compile Include="Utils\ApplicationKeys.cs" />
     <Compile Include="Utils\AchievementType.cs" />
+    <Compile Include="Utils\ApplicationKeys.cs" />
+    <Compile Include="Utils\AsyncSynchronisationContext.cs" />
     <Compile Include="Utils\AudioUtils.cs" />
     <Compile Include="Utils\CollectionExtensions.cs" />
     <Compile Include="Utils\Converters.cs" />

--- a/PokemonGo-UWP/Utils/AsyncSynchronisationContext.cs
+++ b/PokemonGo-UWP/Utils/AsyncSynchronisationContext.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading;
+using PokemonGo.RocketAPI;
+
+namespace PokemonGo_UWP.Utils
+{
+    public class AsyncSynchronizationContext : SynchronizationContext
+    {
+        public static AsyncSynchronizationContext Register()
+        {
+            var syncContext = Current;
+            if (syncContext == null)
+                throw new InvalidOperationException("Ensure a synchronization context exists before calling this method.");
+
+            var customSynchronizationContext = syncContext as AsyncSynchronizationContext;
+
+            if (customSynchronizationContext == null)
+            {
+                customSynchronizationContext = new AsyncSynchronizationContext(syncContext);
+                SetSynchronizationContext(customSynchronizationContext);
+            }
+
+            return customSynchronizationContext;
+        }
+
+        private readonly SynchronizationContext _syncContext;
+
+        public AsyncSynchronizationContext(SynchronizationContext syncContext)
+        {
+            _syncContext = syncContext;
+        }
+
+        public override SynchronizationContext CreateCopy()
+        {
+            return new AsyncSynchronizationContext(_syncContext.CreateCopy());
+        }
+
+        public override void OperationCompleted()
+        {
+            _syncContext.OperationCompleted();
+        }
+
+        public override void OperationStarted()
+        {
+            _syncContext.OperationStarted();
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            _syncContext.Post(WrapCallback(d), state);
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            _syncContext.Send(d, state);
+        }
+
+        private static SendOrPostCallback WrapCallback(SendOrPostCallback sendOrPostCallback)
+        {
+            return state =>
+            {
+                Exception exception = null;
+
+                try
+                {
+                    sendOrPostCallback(state);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                if (exception != null)
+                    Logger.Write(exception.Message);
+            };
+        }
+    }
+}


### PR DESCRIPTION
AsyncSynchronizationContext let catch exceptions from async void methods
(UI methods from events) before it crashes the app.