### PR TITLE
Remember Map Zoom Fixes

### DIFF
--- a/PokemonGo-UWP/Strings/en-US/Resources.resw
+++ b/PokemonGo-UWP/Strings/en-US/Resources.resw
@@ -262,16 +262,16 @@ Open page with installation files for manual install?</value>
     <value>Level</value>
   </data>
   <data name="MapAutoRotateTitleText.Text" xml:space="preserve">
-    <value>Autorotate map</value>
+    <value>Auto-Rotate Map</value>
   </data>
   <data name="PokemonCaughtByType" xml:space="preserve">
-    <value>different Pokemons caught</value>
+    <value>Different Pokemon caught</value>
   </data>
   <data name="PokemonsCaptured" xml:space="preserve">
-    <value>Pokemons captured</value>
+    <value>Pokemon captured</value>
   </data>
   <data name="PokemonsEncountered" xml:space="preserve">
-    <value>Pokemons encountered</value>
+    <value>Pokemon encountered</value>
   </data>
   <data name="DateFormat" xml:space="preserve">
     <value>dd.MM.yyyy</value>

--- a/PokemonGo-UWP/Utils/SettingsService.cs
+++ b/PokemonGo-UWP/Utils/SettingsService.cs
@@ -101,10 +101,10 @@ namespace PokemonGo_UWP.Utils
             set { _helper.Write(nameof(IsAutoRotateMapEnabled), value); }
         }
 
-        public bool IsMapZoomEnabled
+        public bool IsRememberMapZoomEnabled
         {
-            get { return _helper.Read(nameof(IsMapZoomEnabled), false); }
-            set { _helper.Write(nameof(IsMapZoomEnabled), value); }
+            get { return _helper.Read(nameof(IsRememberMapZoomEnabled), false); }
+            set { _helper.Write(nameof(IsRememberMapZoomEnabled), value); }
         }
         
         public double Zoomlevel

--- a/PokemonGo-UWP/ViewModels/SettingsPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/SettingsPageViewModel.cs
@@ -37,10 +37,10 @@ namespace PokemonGo_UWP.ViewModels
             set { SettingsService.Instance.IsAutoRotateMapEnabled = value; }
         }
 
-        public bool IsMapZoomEnabled
+        public bool IsRememberMapZoomEnabled
         {
-            get { return SettingsService.Instance.IsMapZoomEnabled; }
-            set { SettingsService.Instance.IsMapZoomEnabled = value; }
+            get { return SettingsService.Instance.IsRememberMapZoomEnabled; }
+            set { SettingsService.Instance.IsRememberMapZoomEnabled = value; }
         }
 
         #endregion

--- a/PokemonGo-UWP/Views/GameMapPage.xaml.cs
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml.cs
@@ -94,14 +94,27 @@ namespace PokemonGo_UWP.Views
 			base.OnNavigatingFrom(e);
 			UnsubscribeToCaptureEvents();
 			SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
-            if (SettingsService.Instance.IsMapZoomEnabled)
+            if (SettingsService.Instance.IsRememberMapZoomEnabled)
             {
-                savezoomlevel();
+                SaveZoomLevel();
             }
 		}
 
-        private void savezoomlevel()
+        private void SaveZoomLevel()
         {
+            // Bug fix for Issue 586
+            if (SettingsService.Instance.Zoomlevel == 0 || GameMapControl.ZoomLevel == 0)
+            {
+                try
+                {
+                    GameMapControl.ZoomLevel = 20;
+                }
+                catch
+                {
+
+                }
+            }
+            // End Bug fix for Issue 586
             SettingsService.Instance.Zoomlevel = GameMapControl.ZoomLevel;
         }
 
@@ -134,7 +147,7 @@ namespace PokemonGo_UWP.Views
 						if (SettingsService.Instance.IsAutoRotateMapEnabled && position.Coordinate.Heading != null && !double.IsNaN(position.Coordinate.Heading.Value))
 						{
 							GameMapControl.Heading = position.Coordinate.Heading.Value;
-                            if (SettingsService.Instance.IsMapZoomEnabled)
+                            if (SettingsService.Instance.IsRememberMapZoomEnabled)
                             {
                                 try
                                 {

--- a/PokemonGo-UWP/Views/SettingsPage.xaml
+++ b/PokemonGo-UWP/Views/SettingsPage.xaml
@@ -78,7 +78,7 @@
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"
                                x:Uid="MapAutoRotateTitleText"
-                               Text="Autorotate map"
+                               Text="Auto-Rotate Map"
                                Style="{StaticResource TextSettingsTitle}"
                                VerticalAlignment="Center" />
 
@@ -94,14 +94,14 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"
-                               x:Uid="MapAutoRotateTitleText"
+                               x:Uid="RememberMapZoomTitleText"
                                Text="Remember Map Zoom"
                                Style="{StaticResource TextSettingsTitle}"
                                VerticalAlignment="Center" />
 
                     <CheckBox Grid.Column="1"
-                              x:Name="MapRememberZoomCheckbox"
-                              IsChecked="{Binding IsAutoRotateMapEnabled, Mode=TwoWay}"
+                              x:Name="RememberMapZoomCheckbox"
+                              IsChecked="{Binding IsRememberMapZoomEnabled, Mode=TwoWay}"
                               Style="{StaticResource SettingsCheckbox}" />
                 </Grid>
 


### PR DESCRIPTION
- Fix for #587.
- Better naming for the "MapZoomEnabled" setting.
- Fix for #586.
- Minor translation fix ("Pokemon" is both singular and plural, should never have an "s" at the end.)