### PR TITLE
Remove NearbyPokemon when Caught or Fled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ obj/
 /.vs/config/applicationhost.config
 /PokemonGo-UWP/Utils/ApplicationKeys.cs
 /PokemonGo-UWP/AppPackages/
+/PokemonGo-UWP/BundleArtifacts/
 *.suo
 *.user
 *.tss

--- a/PokemonGo-UWP/App.xaml.cs
+++ b/PokemonGo-UWP/App.xaml.cs
@@ -59,7 +59,7 @@ namespace PokemonGo_UWP
             HockeyClient.Current.TrackException(e.Exception);
         }
 
-        #region Notify
+        #region Toast & Notifications
 
         /// <summary>
         ///     Vibrates and/or plays a sound when new pokemons are in the area

--- a/PokemonGo-UWP/Utils/GameClient.cs
+++ b/PokemonGo-UWP/Utils/GameClient.cs
@@ -36,6 +36,7 @@ namespace PokemonGo_UWP.Utils
 
         private static ISettings _clientSettings;
         private static Client _client;
+        private static readonly int _mapUpdateInterval = 10;
 
         /// <summary>
         ///     Handles failures by having a fixed number of retries
@@ -322,12 +323,12 @@ namespace PokemonGo_UWP.Utils
             };
             _mapUpdateTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromSeconds(10)
+                Interval = TimeSpan.FromSeconds(_mapUpdateInterval)
             };
             _mapUpdateTimer.Tick += async (s, e) =>
             {
                 // Update before starting but only if more than 10s passed since the last one
-                if ((DateTime.Now - _lastUpdate).Seconds <= 10) return;
+                if ((DateTime.Now - _lastUpdate).Seconds <= _mapUpdateInterval) return;
                 Logger.Write("Updating map");
                 await UpdateMapObjects();
             };
@@ -355,7 +356,7 @@ namespace PokemonGo_UWP.Utils
             {
                 if (_mapUpdateTimer.IsEnabled) return;
                 // Update before starting but only if more than 10s passed since the last one
-                if ((DateTime.Now - _lastUpdate).Seconds > 10)
+                if ((DateTime.Now - _lastUpdate).Seconds > _mapUpdateInterval)
                     await UpdateMapObjects();
                 _mapUpdateTimer.Start();
             }

--- a/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
@@ -272,7 +272,7 @@ namespace PokemonGo_UWP.ViewModels
                 case CatchPokemonResponse.Types.CatchStatus.CatchEscape:
                     Logger.Write($"{CurrentPokemon.PokemonId} escaped");
                     CatchEscape?.Invoke(this, null);
-                    //TODO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
+                    //TO DO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
                     //                         so the user can try again.
                     break;
                 case CatchPokemonResponse.Types.CatchStatus.CatchFlee:

--- a/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
@@ -252,9 +252,10 @@ namespace PokemonGo_UWP.ViewModels
         private async Task ThrowPokeball(bool hitPokemon)
         {
             var caughtPokemonResponse =
-                await
-                    GameClient.CatchPokemon(CurrentPokemon.EncounterId, CurrentPokemon.SpawnpointId,
+                await GameClient.CatchPokemon(CurrentPokemon.EncounterId, CurrentPokemon.SpawnpointId,
                         SelectedCaptureItem.ItemId, hitPokemon);
+            var nearbyPokemon = GameClient.NearbyPokemons.FirstOrDefault(pokemon => pokemon.EncounterId == CurrentPokemon.EncounterId);
+
             switch (caughtPokemonResponse.Status)
             {
                 case CatchPokemonResponse.Types.CatchStatus.CatchError:
@@ -266,19 +267,22 @@ namespace PokemonGo_UWP.ViewModels
                     CurrentCaptureAward = caughtPokemonResponse.CaptureAward;
                     CatchSuccess?.Invoke(this, null);
                     GameClient.CatchablePokemons.Remove(CurrentPokemon);
+                    GameClient.NearbyPokemons.Remove(nearbyPokemon);
                     break;
                 case CatchPokemonResponse.Types.CatchStatus.CatchEscape:
                     Logger.Write($"{CurrentPokemon.PokemonId} escaped");
                     CatchEscape?.Invoke(this, null);
+                    //TODO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
+                    //                         so the user can try again.
                     break;
                 case CatchPokemonResponse.Types.CatchStatus.CatchFlee:
                     Logger.Write($"{CurrentPokemon.PokemonId} fled");
                     CatchFlee?.Invoke(this, null);
                     // TODO: animation and navigate back to map page to remove this ugly message
-                    await
-                        new MessageDialog(string.Format(Resources.CodeResources.GetString("Fled"),
+                    await new MessageDialog(string.Format(Resources.CodeResources.GetString("Fled"),
                             Resources.Pokemon.GetString(CurrentPokemon.PokemonId.ToString()))).ShowAsyncQueue();
                     GameClient.CatchablePokemons.Remove(CurrentPokemon);
+                    GameClient.NearbyPokemons.Remove(nearbyPokemon);
                     // We just go back because there's nothing else to do
                     NavigationService.GoBack();
                     break;

--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
@@ -9,8 +9,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
 using PokemonGo.RocketAPI;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace PokemonGo_UWP.Views
 {
     /// <summary>
@@ -215,6 +213,8 @@ namespace PokemonGo_UWP.Views
         private void GameManagerViewModelOnCatchEscape(object sender, EventArgs eventArgs)
         {
             CatchEscape.Begin();
+            //TODO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
+            //                         so the user can try again.
         }
 
         private void GameManagerViewModelOnCatchSuccess(object sender, EventArgs eventArgs)

--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
@@ -213,7 +213,7 @@ namespace PokemonGo_UWP.Views
         private void GameManagerViewModelOnCatchEscape(object sender, EventArgs eventArgs)
         {
             CatchEscape.Begin();
-            //TODO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
+            //TO DO (from advancedrei): This storyboard needs to delay 3 seconds, then reverse the animation
             //                         so the user can try again.
         }
 


### PR DESCRIPTION
- Central place to change the update timer if Ninantic ever goes back to
5 second refresh intervals.
- Remove Pokemon from the `GameClient.NearbyPokemon` ObservableCollection when they
are caught or flee.
- .gitignore updates.

(PS, LOVE the refactor. Code is much cleaner now.)