### PR TITLE
fixed "got a *** Candy.." message to display pokemon familiy name

### DIFF
--- a/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
@@ -301,7 +301,7 @@ namespace PokemonGo_UWP.ViewModels
                       await
                           new MessageDialog(
                               string.Format(Resources.CodeResources.GetString("TransferPokemonSuccessText"),
-                                  Resources.Pokemon.GetString(CurrentPokemon.PokemonId.ToString()))).ShowAsyncQueue();
+                                  Resources.Pokemon.GetString(CurrentCandy.FamilyId.ToString().Replace("Family", "")))).ShowAsyncQueue();
                       await GameClient.UpdateInventory();
                       NavigationService.Navigate(typeof(PokemonInventoryPage));
                       break;


### PR DESCRIPTION
Instead of current pokemon name.

Not the most elegant way, just copied from the converter.