### PR TITLE
Added LoginFailedException message from http response

### DIFF
--- a/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
@@ -9,6 +9,7 @@ using PokemonGo_UWP.Views;
 using Template10.Mvvm;
 using Template10.Services.NavigationService;
 using Universal_Authenticator_v2.Views;
+using Newtonsoft.Json.Linq;
 
 namespace PokemonGo_UWP.ViewModels
 {
@@ -140,11 +141,20 @@ namespace PokemonGo_UWP.ViewModels
                 {
                     await new MessageDialog(Resources.CodeResources.GetString("PtcDownText")).ShowAsyncQueue();
                 }
-                catch (LoginFailedException)
+                catch (LoginFailedException e)
                 {
-                    await
-                        new MessageDialog(Resources.CodeResources.GetString("LoginFailedText"))
-                            .ShowAsyncQueue();
+                    string errorMessage = Resources.CodeResources.GetString("LoginFailedText");
+
+                    try
+                    {
+                        Task<string> result = e.GetLoginResponseContentAsString();
+                        JObject json = JObject.Parse(result.Result);
+                        JToken token = json.SelectToken("$.errors[0]");
+                        if (token != null)
+                            errorMessage = token.ToString();
+                    } catch { }
+
+                    await new MessageDialog(errorMessage).ShowAsyncQueue();
                 }
                 finally
                 {


### PR DESCRIPTION
I was checking the responses from login requests and maybe this can be nice to add. I have checked with the official app and they are the same apparently. I don't like too much the try-catch but I put it just in case something change from the server side. I am not very familiar with C# so improvements are welcome :)

This is how it looks like:

![capture](https://cloud.githubusercontent.com/assets/7131226/17646500/af6d7bd8-61cc-11e6-85f9-095bc0ba658a.PNG)
![capture2](https://cloud.githubusercontent.com/assets/7131226/17646501/af6dffa4-61cc-11e6-865e-42cba7b336f7.PNG)




