### PR TITLE
Fix errors from output window

### DIFF
--- a/PokemonGo-UWP/Utils/GameClient.cs
+++ b/PokemonGo-UWP/Utils/GameClient.cs
@@ -20,6 +20,7 @@ using POGOProtos.Enums;
 using POGOProtos.Inventory;
 using POGOProtos.Inventory.Item;
 using POGOProtos.Map.Fort;
+using POGOProtos.Map.Pokemon;
 using POGOProtos.Networking.Envelopes;
 using POGOProtos.Networking.Responses;
 using POGOProtos.Settings;
@@ -123,7 +124,13 @@ namespace PokemonGo_UWP.Utils
         ///     Collection of Pokemon in 2 steps from current position
         /// </summary>
         public static ObservableCollection<NearbyPokemonWrapper> NearbyPokemons { get; set; } =
-            new ObservableCollection<NearbyPokemonWrapper>();
+            new ObservableCollection<NearbyPokemonWrapper>
+            {
+                //To prevent errors from NearbyPokemons[0-2].PokemonId in GameMapPage.xaml
+                new NearbyPokemonWrapper(new NearbyPokemon {PokemonId = 0}),
+                new NearbyPokemonWrapper(new NearbyPokemon {PokemonId = 0}),
+                new NearbyPokemonWrapper(new NearbyPokemon {PokemonId = 0})
+            };
 
         /// <summary>
         ///     Collection of Pokestops in the current area
@@ -237,6 +244,8 @@ namespace PokemonGo_UWP.Utils
             {
                 if (e is PokemonGo.RocketAPI.Exceptions.AccessTokenExpiredException)
                 {
+                    Debug.WriteLine("AccessTokenExpired Exception caught");
+                    Debug.WriteLine("Loging in now");
                     await Relogin();
                 }
                 else throw;
@@ -333,7 +342,7 @@ namespace PokemonGo_UWP.Utils
             _geolocator = null;
             CatchablePokemons.Clear();
             NearbyPokemons.Clear();
-            NearbyPokestops.Clear();            
+            NearbyPokestops.Clear();
         }
 
         public static async Task DoRelogin()
@@ -431,7 +440,8 @@ namespace PokemonGo_UWP.Utils
             Geoposition = args.Position;
             // Updating player's position
             var position = Geoposition.Coordinate.Point.Position;
-            await _client.Player.UpdatePlayerLocation(position.Latitude, position.Longitude, position.Altitude);
+            if (_client != null)
+                await _client.Player.UpdatePlayerLocation(position.Latitude, position.Longitude, position.Altitude);
             GeopositionUpdated?.Invoke(null, Geoposition);
         }
 


### PR DESCRIPTION
#Fixes:

- No known issues associated 

#Changes:

- Add 3 empty NearbyPokemons at startup
- Add null check for _client in _geolocator.PositionChanged

#Change details:

- Without those 3 empty pokemons the GameMapPage was Binding indexes 0-2 to empty array, which gave errors, but worked afterwards. Now it's without errors.
- Without null check for _client it was throwing null in some cases.