### PR TITLE
Fix suspension serialization

### DIFF
--- a/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo.RocketAPI;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
@@ -47,15 +48,15 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                CurrentPokemon = (MapPokemonWrapper) suspensionState[nameof(CurrentPokemon)];
-                CurrentEncounter = (EncounterResponse) suspensionState[nameof(CurrentEncounter)];
-                CurrentCaptureAward = (CaptureAward) suspensionState[nameof(CurrentCaptureAward)];
-                SelectedCaptureItem = (ItemData) suspensionState[nameof(SelectedCaptureItem)];
+                CurrentPokemon = JsonConvert.DeserializeObject<MapPokemonWrapper>((string)suspensionState[nameof(CurrentPokemon)]);
+                CurrentEncounter = JsonConvert.DeserializeObject<EncounterResponse>((string)suspensionState[nameof(CurrentEncounter)]);
+                CurrentCaptureAward = JsonConvert.DeserializeObject<CaptureAward>((string)suspensionState[nameof(CurrentCaptureAward)]);
+                SelectedCaptureItem = JsonConvert.DeserializeObject<ItemData>((string)suspensionState[nameof(SelectedCaptureItem)]);
             }
             else
             {
-                // Navigating from game page, so we need to actually load the encounter                
-                CurrentPokemon = (MapPokemonWrapper) NavigationHelper.NavigationState[nameof(CurrentPokemon)];
+                // Navigating from game page, so we need to actually load the encounter
+                CurrentPokemon = (MapPokemonWrapper)NavigationHelper.NavigationState[nameof(CurrentPokemon)];
                 Busy.SetBusy(true,
                     string.Format(Resources.CodeResources.GetString("LoadingEncounterText"),
                         Resources.Pokemon.GetString(CurrentPokemon.PokemonId.ToString())));
@@ -84,10 +85,10 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(CurrentPokemon)] = CurrentPokemon;
-                suspensionState[nameof(CurrentEncounter)] = CurrentEncounter;
-                suspensionState[nameof(CurrentCaptureAward)] = CurrentCaptureAward;
-                suspensionState[nameof(SelectedCaptureItem)] = SelectedCaptureItem;
+                suspensionState[nameof(CurrentPokemon)] = JsonConvert.SerializeObject(CurrentPokemon);
+                suspensionState[nameof(CurrentEncounter)] = JsonConvert.SerializeObject(CurrentEncounter);
+                suspensionState[nameof(CurrentCaptureAward)] = JsonConvert.SerializeObject(CurrentCaptureAward);
+                suspensionState[nameof(SelectedCaptureItem)] = JsonConvert.SerializeObject(SelectedCaptureItem);
             }
             await Task.CompletedTask;
         }
@@ -225,7 +226,7 @@ namespace PokemonGo_UWP.ViewModels
         /// </summary>
         private void SelectStartingBall()
         {
-            // Set default item (switch to other balls if user has none)            
+            // Set default item (switch to other balls if user has none)
             SelectedCaptureItem = ItemsInventory.First(item => item.ItemId == ItemId.ItemPokeBall) ?? new ItemData
             {
                 Count = 0,
@@ -319,7 +320,7 @@ namespace PokemonGo_UWP.ViewModels
                     break;
                 case CatchPokemonResponse.Types.CatchStatus.CatchEscape:
                     Logger.Write($"{CurrentPokemon.PokemonId} escaped");
-                    CatchEscape?.Invoke(this, null);                    
+                    CatchEscape?.Invoke(this, null);
                     break;
                 case CatchPokemonResponse.Types.CatchStatus.CatchFlee:
                     Logger.Write($"{CurrentPokemon.PokemonId} fled");

--- a/PokemonGo-UWP/ViewModels/EggDetailPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/EggDetailPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo.RocketAPI;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
@@ -31,13 +32,13 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                CurrentEgg = (PokemonDataWrapper) suspensionState[nameof(CurrentEgg)];
-                SelectedEggIncubator = (EggIncubator) suspensionState[nameof(SelectedEggIncubator)];
+                CurrentEgg = JsonConvert.DeserializeObject<PokemonDataWrapper>((string)suspensionState[nameof(CurrentEgg)]);
+                SelectedEggIncubator = JsonConvert.DeserializeObject<EggIncubator>((string)suspensionState[nameof(SelectedEggIncubator)]);
             }
             else
             {
-                // Navigating from game page, so we need to actually load the encounter                
-                CurrentEgg = (PokemonDataWrapper) NavigationHelper.NavigationState[nameof(CurrentEgg)];
+                // Navigating from game page, so we need to actually load the encounter
+                CurrentEgg = (PokemonDataWrapper)NavigationHelper.NavigationState[nameof(CurrentEgg)];
             }
             await Task.CompletedTask;
         }
@@ -52,8 +53,8 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(CurrentEgg)] = CurrentEgg;
-                suspensionState[nameof(SelectedEggIncubator)] = SelectedEggIncubator;
+                suspensionState[nameof(CurrentEgg)] = JsonConvert.SerializeObject(CurrentEgg);
+                suspensionState[nameof(SelectedEggIncubator)] = JsonConvert.SerializeObject(SelectedEggIncubator);
             }
             await Task.CompletedTask;
         }
@@ -134,7 +135,7 @@ namespace PokemonGo_UWP.ViewModels
         public event EventHandler IncubatorSuccess;
 
         #endregion
-        
+
         private DelegateCommand<EggIncubator> _useIncubatorCommand;
 
         public DelegateCommand<EggIncubator> UseIncubatorCommand => _useIncubatorCommand ?? (
@@ -149,7 +150,7 @@ namespace PokemonGo_UWP.ViewModels
                         CurrentEgg =
                             new PokemonDataWrapper(GameClient.EggsInventory.First(item => item.Id == CurrentEgg.Id));
                         break;
-                    default:                        
+                    default:
                         Logger.Write($"Error using {incubator.Id} on {CurrentEgg.Id}");
                         break;
                 }

--- a/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
@@ -43,8 +43,8 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                PlayerProfile = (PlayerData)JsonConvert.DeserializeObject((string)suspensionState[nameof(PlayerProfile)]);
-                PlayerStats = (PlayerStats)JsonConvert.DeserializeObject((string)suspensionState[nameof(PlayerStats)]);
+                PlayerProfile = JsonConvert.DeserializeObject<PlayerData>((string)suspensionState[nameof(PlayerProfile)]);
+                PlayerStats = JsonConvert.DeserializeObject<PlayerStats>((string)suspensionState[nameof(PlayerStats)]);
                 // Restarting update service
                 await StartGpsDataService();
                 return;

--- a/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
@@ -7,6 +7,7 @@ using Windows.Devices.Geolocation;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo.RocketAPI;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
@@ -42,8 +43,8 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                PlayerProfile = (PlayerData)suspensionState[nameof(PlayerProfile)];
-                PlayerStats = (PlayerStats)suspensionState[nameof(PlayerStats)];
+                PlayerProfile = (PlayerData)JsonConvert.DeserializeObject((string)suspensionState[nameof(PlayerProfile)]);
+                PlayerStats = (PlayerStats)JsonConvert.DeserializeObject((string)suspensionState[nameof(PlayerStats)]);
                 // Restarting update service
                 await StartGpsDataService();
                 return;
@@ -86,8 +87,8 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(PlayerProfile)] = PlayerProfile;
-                suspensionState[nameof(PlayerStats)] = PlayerStats;
+                suspensionState[nameof(PlayerProfile)] = JsonConvert.SerializeObject(PlayerProfile);
+                suspensionState[nameof(PlayerStats)] = JsonConvert.SerializeObject(PlayerStats);
             }
             await Task.CompletedTask;
         }

--- a/PokemonGo-UWP/ViewModels/ItemsInventoryPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/ItemsInventoryPageViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
 using PokemonGo_UWP.Views;
@@ -27,7 +28,7 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                ItemsInventory = (ObservableCollection<ItemDataWrapper>) suspensionState[nameof(ItemsInventory)];
+                ItemsInventory = JsonConvert.DeserializeObject<ObservableCollection<ItemDataWrapper>>((string)suspensionState[nameof(ItemsInventory)]);
             }
             else if (parameter is bool)
             {
@@ -54,7 +55,7 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(ItemsInventory)] = ItemsInventory;
+                suspensionState[nameof(ItemsInventory)] = JsonConvert.SerializeObject(ItemsInventory);
             }
             await Task.CompletedTask;
         }

--- a/PokemonGo-UWP/ViewModels/PlayerProfileViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PlayerProfileViewModel.cs
@@ -10,6 +10,7 @@ using POGOProtos.Enums;
 using Template10.Mvvm;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Controls;
+using Newtonsoft.Json;
 using PokemonGo_UWP.Views;
 using Template10.Common;
 
@@ -30,13 +31,13 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspensionState.Any())
             {
-                // Recovering the state                                
-                PlayerProfile = (PlayerData) suspensionState[nameof(PlayerProfile)];
-                PlayerStats = (PlayerStats) suspensionState[nameof(PlayerStats)];
+                // Recovering the state
+                PlayerProfile = JsonConvert.DeserializeObject<PlayerData>((string)suspensionState[nameof(PlayerProfile)]);
+                PlayerStats = JsonConvert.DeserializeObject<PlayerStats>((string)suspensionState[nameof(PlayerStats)]);
             }
             else
             {
-                // No saved state, get them from the client                                
+                // No saved state, get them from the client
                 PlayerProfile = GameClient.PlayerProfile;
                 PlayerStats = GameClient.PlayerStats;
             }
@@ -54,8 +55,8 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(PlayerProfile)] = PlayerProfile;
-                suspensionState[nameof(PlayerStats)] = PlayerStats;
+                suspensionState[nameof(PlayerProfile)] = JsonConvert.SerializeObject(PlayerProfile);
+                suspensionState[nameof(PlayerStats)] = JsonConvert.SerializeObject(PlayerStats);
             }
             await Task.CompletedTask;
         }

--- a/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
@@ -8,6 +8,7 @@ using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Navigation;
 using Google.Common.Geometry;
+using Newtonsoft.Json;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
 using PokemonGo_UWP.Views;
@@ -28,7 +29,7 @@ namespace PokemonGo_UWP.ViewModels
         #region Lifecycle Handlers
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="parameter">MapPokemonWrapper containing the Pokemon that we're trying to capture</param>
         /// <param name="mode"></param>
@@ -40,13 +41,13 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                CurrentPokemon = (PokemonDataWrapper) suspensionState[nameof(CurrentPokemon)];
-                PlayerProfile = (PlayerData) suspensionState[nameof(PlayerProfile)];
+                CurrentPokemon = JsonConvert.DeserializeObject<PokemonDataWrapper>((string)suspensionState[nameof(CurrentPokemon)]);
+                PlayerProfile = JsonConvert.DeserializeObject<PlayerData>((string)suspensionState[nameof(PlayerProfile)]);
             }
             else
             {
-                // Navigating from inventory page so we need to load the pokemon               
-                CurrentPokemon = (PokemonDataWrapper) NavigationHelper.NavigationState[nameof(CurrentPokemon)];                
+                // Navigating from inventory page so we need to load the pokemon
+                CurrentPokemon = (PokemonDataWrapper)NavigationHelper.NavigationState[nameof(CurrentPokemon)];
                 UpdateCurrentData();
             }
             await Task.CompletedTask;
@@ -62,8 +63,8 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(CurrentPokemon)] = CurrentPokemon;
-                suspensionState[nameof(PlayerProfile)] = PlayerProfile;
+                suspensionState[nameof(CurrentPokemon)] = JsonConvert.SerializeObject(CurrentPokemon);
+                suspensionState[nameof(PlayerProfile)] = JsonConvert.SerializeObject(PlayerProfile);
             }
             await Task.CompletedTask;
         }
@@ -216,7 +217,7 @@ namespace PokemonGo_UWP.ViewModels
             get { return _currentCandy; }
             set
             {
-                Set(ref _currentCandy, value); 
+                Set(ref _currentCandy, value);
                 EvolvePokemonCommand.RaiseCanExecuteChanged();
             }
         }
@@ -284,7 +285,7 @@ namespace PokemonGo_UWP.ViewModels
           {
               // Ask for confirmation before moving the Pokemon
               // TODO: better style maybe?
-              var dialog = 
+              var dialog =
                   new MessageDialog(string.Format(Resources.CodeResources.GetString("TransferPokemonWarningText"),
                       Resources.Pokemon.GetString(CurrentPokemon.PokemonId.ToString())));
               dialog.Commands.Add(new UICommand(Resources.CodeResources.GetString("YesText")) { Id = 0 });
@@ -317,7 +318,7 @@ namespace PokemonGo_UWP.ViewModels
                       break;
                   default:
                       throw new ArgumentOutOfRangeException();
-              }                  
+              }
           }, () => true));
 
         #endregion

--- a/PokemonGo-UWP/ViewModels/PokemonInventoryPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokemonInventoryPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
 using PokemonGo_UWP.Views;
@@ -39,8 +40,8 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                PokemonInventory = (ObservableCollection<PokemonDataWrapper>) suspensionState[nameof(PokemonInventory)];
-                EggsInventory = (ObservableCollection<PokemonDataWrapper>) suspensionState[nameof(EggsInventory)];
+                PokemonInventory = JsonConvert.DeserializeObject<ObservableCollection<PokemonDataWrapper>>((string)suspensionState[nameof(PokemonInventory)]);
+                EggsInventory = JsonConvert.DeserializeObject<ObservableCollection<PokemonDataWrapper>>((string)suspensionState[nameof(EggsInventory)]);
             }
             else
             {
@@ -83,8 +84,8 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(PokemonInventory)] = PokemonInventory;
-                suspensionState[nameof(EggsInventory)] = EggsInventory;
+                suspensionState[nameof(PokemonInventory)] = JsonConvert.SerializeObject(PokemonInventory);
+                suspensionState[nameof(EggsInventory)] = JsonConvert.SerializeObject(EggsInventory);
             }
             await Task.CompletedTask;
         }
@@ -110,7 +111,7 @@ namespace PokemonGo_UWP.ViewModels
                 SettingsService.Instance.PokemonSortingMode = value;
                 RaisePropertyChanged(nameof(CurrentPokemonSortingMode));
 
-                // When this changes we need to sort the collection again     
+                // When this changes we need to sort the collection again
                 UpdateSorting();
             }
         }
@@ -160,7 +161,7 @@ namespace PokemonGo_UWP.ViewModels
 
         #endregion
 
-        #region Pokemon Inventory Handling        
+        #region Pokemon Inventory Handling
 
         private void UpdateSorting()
         {

--- a/PokemonGo-UWP/ViewModels/SearchPokeStopPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/SearchPokeStopPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Navigation;
+using Newtonsoft.Json;
 using PokemonGo.RocketAPI;
 using PokemonGo.RocketAPI.Extensions;
 using PokemonGo_UWP.Entities;
@@ -33,21 +34,21 @@ namespace PokemonGo_UWP.ViewModels
             if (suspensionState.Any())
             {
                 // Recovering the state
-                CurrentPokestop = (FortDataWrapper) suspensionState[nameof(CurrentPokestop)];
-                CurrentPokestopInfo = (FortDetailsResponse) suspensionState[nameof(CurrentPokestopInfo)];
-                CurrentSearchResponse = (FortSearchResponse) suspensionState[nameof(CurrentSearchResponse)];
+                CurrentPokestop = JsonConvert.DeserializeObject<FortDataWrapper>((string)suspensionState[nameof(CurrentPokestop)]);
+                CurrentPokestopInfo = JsonConvert.DeserializeObject<FortDetailsResponse>((string)suspensionState[nameof(CurrentPokestopInfo)]);
+                CurrentSearchResponse = JsonConvert.DeserializeObject<FortSearchResponse>((string)suspensionState[nameof(CurrentSearchResponse)]);
             }
             else
             {
-                // Navigating from game page, so we need to actually load the Pokestop                  
+                // Navigating from game page, so we need to actually load the Pokestop
                 Busy.SetBusy(true, "Loading Pokestop");
-                CurrentPokestop = (FortDataWrapper) NavigationHelper.NavigationState[nameof(CurrentPokestop)];
+                CurrentPokestop = (FortDataWrapper)NavigationHelper.NavigationState[nameof(CurrentPokestop)];
                 NavigationHelper.NavigationState.Remove(nameof(CurrentPokestop));
                 Logger.Write($"Searching {CurrentPokestop.Id}");
                 CurrentPokestopInfo =
                     await GameClient.GetFort(CurrentPokestop.Id, CurrentPokestop.Latitude, CurrentPokestop.Longitude);
                 Busy.SetBusy(false);
-                // If timeout is expired we can go to to pokestop page          
+                // If timeout is expired we can go to to pokestop page
                 if (CurrentPokestop.CooldownCompleteTimestampMs >= DateTime.UtcNow.ToUnixTime())
                 {
                     // Timeout is not expired yet, player can't get items from the fort
@@ -66,9 +67,9 @@ namespace PokemonGo_UWP.ViewModels
         {
             if (suspending)
             {
-                suspensionState[nameof(CurrentPokestop)] = CurrentPokestop;
-                suspensionState[nameof(CurrentPokestopInfo)] = CurrentPokestopInfo;
-                suspensionState[nameof(CurrentSearchResponse)] = CurrentSearchResponse;
+                suspensionState[nameof(CurrentPokestop)] = JsonConvert.SerializeObject(CurrentPokestop);
+                suspensionState[nameof(CurrentPokestopInfo)] = JsonConvert.SerializeObject(CurrentPokestopInfo);
+                suspensionState[nameof(CurrentSearchResponse)] = JsonConvert.SerializeObject(CurrentSearchResponse);
             }
             await Task.CompletedTask;
         }


### PR DESCRIPTION
#Fixes:

- Possible fix for #789 and #791

#Changes:

- Fix serialization of PlayerProfile and PlayerStats

#Change details:

- Serialization didn't work, because ```IDictionary<string, object> suspensionState``` can only save types implementing IPropertySet. So I changed it to use Json serialization/deserialization