### PR TITLE
Tiny typo error fix in GameMapPage

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -253,7 +253,7 @@
                     <Border CornerRadius="8,8,0,0"
                             Margin="16,0"
                             Background="White"
-                            x:Name="NarbyPokemonGrid">
+                            x:Name="NearbyPokemonGrid">
                         <Border Padding="8">
                             <Grid>
                                 <Grid.RowDefinitions>


### PR DESCRIPTION
I found this while browsing the code, I don't know if it will change anything since this border name is not referenced but it's still better to have it with the right name.