### PR TITLE
Corrected CodeResources.resw (en-US)

### DIFF
--- a/PokemonGo-UWP/Strings/en-US/CodeResources.resw
+++ b/PokemonGo-UWP/Strings/en-US/CodeResources.resw
@@ -213,7 +213,7 @@ Open page with installation files for manual install?</value>
     <value>Pokémon Caught</value>
   </data>
   <data name="ActivityCatchLegendPokemon" xml:space="preserve">
-    <value>Catch Legend Pokémon</value>
+    <value>Catch Legendary Pokémon</value>
   </data>
   <data name="ActivityFleePokemon" xml:space="preserve">
     <value>Pokémon Fled</value>


### PR DESCRIPTION
#Changes:

- Changed "Catch Legendary Pokémon"

#Change details:

Before it was written "Catch Legend Pokémon" that's incorrect 

