### PR TITLE
FIX: Broken build

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -252,8 +252,7 @@
 
                     <Border CornerRadius="8,8,0,0"
                             Margin="16,0"
-                            Background="White"
-                            x:Name="NearbyPokemonGrid">
+                            Background="White">
                         <Border Padding="8">
                             <Grid>
                                 <Grid.RowDefinitions>


### PR DESCRIPTION
Fixing #8b7d615 to remove the border name. The fix provided in that checkin duplicated an existing XAML name.