### PR TITLE
Removed random green border

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -592,7 +592,6 @@
             <Border CornerRadius="8,0,0,8"
                     x:Name="NearbyPokemonGrid"
                     BorderThickness="2,2,0,2"
-                    BorderBrush="#abefca"
                     VerticalAlignment="Center"
                     Grid.Column="2"
                     Padding="8,8,0,8"


### PR DESCRIPTION
#Fixes: 
-No corresponding issue number

#Changes:

- Removed ugly border at the NearbyPokemonGrid

#Change details:
Removed the border brush so nothing will be misplaced. The original app doesn't have a green border there.
Here's a comparison of the original app and ours:

![image](https://cloud.githubusercontent.com/assets/13438702/17676577/837335fe-632f-11e6-8aef-b73d61c3c67c.png)

#Other informations:

