### PR TITLE
Change team colours

### DIFF
--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -255,8 +255,6 @@ namespace PokemonGo_UWP.Utils
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             var teamColor = (TeamColor) value;
-            var currentTime = int.Parse(DateTime.Now.ToString("HH"));
-            var noTeamColor = currentTime > 7 && currentTime < 19 ? Colors.Black : Colors.White;
             return new SolidColorBrush(teamColor == TeamColor.Neutral
                 ? Color.FromArgb(255, 26, 237, 213)
                 : teamColor == TeamColor.Blue ? Color.FromArgb(255, 36, 176, 253) : teamColor == TeamColor.Red ? Color.FromArgb(255, 237, 90, 90) : Color.FromArgb(255, 254, 225, 63));

--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -259,7 +259,7 @@ namespace PokemonGo_UWP.Utils
             var noTeamColor = currentTime > 7 && currentTime < 19 ? Colors.Black : Colors.White;
             return new SolidColorBrush(teamColor == TeamColor.Neutral
                 ? noTeamColor
-                : teamColor == TeamColor.Blue ? Colors.Blue : teamColor == TeamColor.Red ? Colors.Red : Colors.Yellow);
+                : teamColor == TeamColor.Blue ? Color.FromArgb(0xFF, 0x00, 0xB1, 0xFF) : teamColor == TeamColor.Red ? Color.FromArgb(0xFF, 0xFE, 0x5A, 0x59) : Color.FromArgb(0xFF, 0xFF, 0xE2, 0x22));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -258,8 +258,8 @@ namespace PokemonGo_UWP.Utils
             var currentTime = int.Parse(DateTime.Now.ToString("HH"));
             var noTeamColor = currentTime > 7 && currentTime < 19 ? Colors.Black : Colors.White;
             return new SolidColorBrush(teamColor == TeamColor.Neutral
-                ? noTeamColor
-                : teamColor == TeamColor.Blue ? Color.FromArgb(0xFF, 0x00, 0xB1, 0xFF) : teamColor == TeamColor.Red ? Color.FromArgb(0xFF, 0xFE, 0x5A, 0x59) : Color.FromArgb(0xFF, 0xFF, 0xE2, 0x22));
+                ? Color.FromArgb(255, 26, 237, 213)
+                : teamColor == TeamColor.Blue ? Color.FromArgb(255, 36, 176, 253) : teamColor == TeamColor.Red ? Color.FromArgb(255, 237, 90, 90) : Color.FromArgb(255, 254, 225, 63));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
#Fixes:

-

#Changes:

- Changed team colors in Converters.cs to the actual colors from the original game. 

#Change details:

The colors are defined as a ARGB using Color.FromArgb. The alpha values are set to 255 in order to create a solid color.

#Other informations:

Color values courtesy of eamax from Discord.