### PR TITLE
Localized EggDetailPage and added German translation. #604

### DIFF
--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.cs.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.cs.xlf
@@ -643,6 +643,14 @@ Chcete otevřít stránku se soubory pro manuální instalaci? </target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.de.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.de.xlf
@@ -641,6 +641,14 @@ Seite zu den Dateien für manuelle Installation öffnen?</target>
           <source>Remember Map Zoom</source>
           <target state="translated">Speichere Karten Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="translated">AUSBRÜTEN BEGINNEN</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="translated">Benutze eine Brutmaschine, um dieses Ei auszubrüten.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.el.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.el.xlf
@@ -642,6 +642,14 @@ Open page with installation files for manual install?</source>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.es.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.es.xlf
@@ -640,6 +640,14 @@ Open page with installation files for manual install?</source>
           <source>TRANSFER</source>
           <target state="translated">Transferir</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fi.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fi.xlf
@@ -815,6 +815,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fr.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fr.xlf
@@ -644,6 +644,14 @@ Ouvrir la page avec les fichiers d'installation pour une installation manuelle ?
           <source>Remember Map Zoom</source>
           <target state="translated">Mémoriser le zoom de la carte</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.hu.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.hu.xlf
@@ -638,6 +638,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.id.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.id.xlf
@@ -638,6 +638,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.it.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.it.xlf
@@ -639,6 +639,14 @@ Vuoi aprire la pagina con il file di installazione per l'installazione manuale?<
           <source>Remember Map Zoom</source>
           <target state="new">Ricorda l'ingrandimento della mappa</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.ja.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.ja.xlf
@@ -638,6 +638,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nl.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nl.xlf
@@ -643,6 +643,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pl.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pl.xlf
@@ -644,6 +644,14 @@ Czy otworzyć stronę z plikami instalacyjnymi w celu instalacji manualnej?</tar
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pt-BR.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pt-BR.xlf
@@ -642,6 +642,14 @@ Abrir a página com os arquivos de instalação para instalação manual?</targe
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pt-PT.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.pt-PT.xlf
@@ -642,6 +642,14 @@ Abrir a página com os arquivos de instalação para instalação manual?</targe
           <source>TRANSFER</source>
           <target state="new">TRANSFER</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.ru.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.ru.xlf
@@ -643,6 +643,14 @@ Open page with installation files for manual install?</source>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.sk.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.sk.xlf
@@ -638,6 +638,14 @@ Open page with installation files for manual install?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.tr.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.tr.xlf
@@ -642,6 +642,14 @@ Elle yükleme için yükleme dosyaları sayfası açılsın mı?</target>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-CN.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-CN.xlf
@@ -644,6 +644,14 @@ Open page with installation files for manual install?</source>
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-HK.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-HK.xlf
@@ -414,6 +414,14 @@
           <source>Remember Map Zoom</source>
           <target state="new">Remember Map Zoom</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-TW.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.zh-TW.xlf
@@ -408,6 +408,14 @@ Open page with installation files for manual install?</source>
           <source>Remember Map Zoom</source>
           <target state="translated">記住地圖縮放</target>
         </trans-unit>
+        <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>START INCUBATION</source>
+          <target state="new">START INCUBATION</target>
+        </trans-unit>
+        <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Use an incubator to incubate the Egg.</source>
+          <target state="new">Use an incubator to incubate the Egg.</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PokemonGo-UWP/Strings/de/Resources.resw
+++ b/PokemonGo-UWP/Strings/de/Resources.resw
@@ -143,4 +143,10 @@
   <data name="SettingsRememberMapZoomTextBlock" xml:space="preserve">
     <value>Speichere Karten Zoom</value>
   </data>
+  <data name="EggDetailButtonTextBlock.Text" xml:space="preserve">
+    <value>AUSBRÜTEN BEGINNEN</value>
+  </data>
+  <data name="EggDetailTextBlock.Text" xml:space="preserve">
+    <value>Benutze eine Brutmaschine, um dieses Ei auszubrüten.</value>
+  </data>
 </root>

--- a/PokemonGo-UWP/Strings/en-US/Resources.resw
+++ b/PokemonGo-UWP/Strings/en-US/Resources.resw
@@ -248,4 +248,10 @@
   <data name="TransferButton.Content" xml:space="preserve">
     <value>TRANSFER</value>
   </data>
+  <data name="EggDetailButtonTextBlock.Text" xml:space="preserve">
+    <value>START INCUBATION</value>
+  </data>
+  <data name="EggDetailTextBlock.Text" xml:space="preserve">
+    <value>Use an incubator to incubate the Egg.</value>
+  </data>
 </root>

--- a/PokemonGo-UWP/Views/EggDetailPage.xaml
+++ b/PokemonGo-UWP/Views/EggDetailPage.xaml
@@ -223,13 +223,14 @@
 
                     <StackPanel Grid.Row="1"
                                 Visibility="{Binding CurrentEgg.EggIncubatorId, Converter={StaticResource VisibleWhenStringEmptyConverter}}">
-                        <TextBlock Text="Use an incubator to incubate the Egg."
+                        <TextBlock x:Uid="EggDetailTextBlock"
+                                   TextWrapping="WrapWholeWords"
                                    HorizontalAlignment="Center" />
 
                         <Button Style="{StaticResource ButtonSubmit}"
                                 Tapped="ToggleIncubatorModel"
                                 Width="180">
-                            <TextBlock Text="START INCUBATION" />
+                            <TextBlock x:Uid="EggDetailButtonTextBlock" />
                         </Button>
                     </StackPanel>
 


### PR DESCRIPTION
**#Fixes:**

- Added word wrap to detail text

**#Changes:**

- Created resources for detail text and button text
- Added German translation

**#Other informations:**

See #604

I'm not sure, if the string "km" is "mi" in the US version and should be put into the resource file, too. Maybe, someone with a US version on Android or iPhone could check this. If it's "mi", what happens to the numbers? What has to be displayed for 2km, 5km and 10km instead? And this could be an issue also regarding the distance one has already walked.