### PR TITLE
Replacing GeoExtensions to GeoHelper

### DIFF
--- a/PokemonGo-UWP/Entities/FortDataWrapper.cs
+++ b/PokemonGo-UWP/Entities/FortDataWrapper.cs
@@ -2,11 +2,11 @@
 using System.ComponentModel;
 using Windows.Devices.Geolocation;
 using Windows.Foundation;
-using GeoExtensions;
 using Google.Protobuf;
 using PokemonGo.RocketAPI.Extensions;
 using PokemonGo_UWP.Utils;
 using PokemonGo_UWP.Utils.Game;
+using PokemonGo_UWP.Utils.Helpers;
 using PokemonGo_UWP.Views;
 using POGOProtos.Enums;
 using POGOProtos.Map.Fort;
@@ -27,8 +27,7 @@ namespace PokemonGo_UWP.Entities
         public FortDataStatus FortDataStatus {
             get
             {
-                var distance = GeoAssist.CalculateDistanceBetweenTwoGeoPoints(Geoposition,
-                GameClient.Geoposition.Coordinate.Point);
+                var distance = GeoHelper.Distance(Geoposition, GameClient.Geoposition.Coordinate.Point);
                 FortDataStatus retVal = FortDataStatus.Opened;
 
                 if (distance > GameClient.GameSetting.FortSettings.InteractionRangeMeters)

--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -9,7 +9,6 @@ using Windows.UI.Xaml.Controls.Maps;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
-using GeoExtensions;
 using Google.Common.Geometry;
 using Google.Protobuf.Collections;
 using PokemonGo.RocketAPI.Extensions;

--- a/PokemonGo-UWP/Utils/Helpers/GeoHelper.cs
+++ b/PokemonGo-UWP/Utils/Helpers/GeoHelper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Windows.Devices.Geolocation;
+
+namespace PokemonGo_UWP.Utils.Helpers
+{
+    class GeoHelper
+    {
+        public static double Distance(Geopoint point1, Geopoint point2)
+        {
+            double theta = (point1.Position.Longitude - point2.Position.Longitude) * Math.PI / 180.0;
+            double lat1 = point1.Position.Latitude * Math.PI / 180.0;
+            double long1 = point1.Position.Longitude * Math.PI / 180.0;
+            double lat2 = point2.Position.Latitude * Math.PI / 180.0;
+            double long2 = point2.Position.Longitude * Math.PI / 180.0;
+            double dist = Math.Sin(lat1) * Math.Sin(lat2) +
+                          Math.Cos(lat1) * Math.Cos(lat2) *
+                          Math.Cos(theta);
+            dist = Math.Acos(dist);
+            dist = dist / Math.PI * 180.0;
+            dist = dist * 60 * 1.1515 * 1.609344 * 1000;
+            return dist;
+        }
+    }
+}

--- a/PokemonGo-UWP/project.json
+++ b/PokemonGo-UWP/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "GeoExtensions": "1.0.0.3",
     "HockeySDK.UWP": "4.1.3",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
@@ -16,11 +15,11 @@
     "uap10.0": {}
   },
   "runtimes": {
-    "win10-arm": { },
-    "win10-arm-aot": { },
-    "win10-x86": { },
-    "win10-x86-aot": { },
-    "win10-x64": { },
-    "win10-x64-aot": { }
+    "win10-arm": {},
+    "win10-arm-aot": {},
+    "win10-x86": {},
+    "win10-x86-aot": {},
+    "win10-x64": {},
+    "win10-x64-aot": {}
   }
 }

--- a/PokemonGo-UWP/project.json
+++ b/PokemonGo-UWP/project.json
@@ -15,11 +15,11 @@
     "uap10.0": {}
   },
   "runtimes": {
-    "win10-arm": {},
-    "win10-arm-aot": {},
-    "win10-x86": {},
-    "win10-x86-aot": {},
-    "win10-x64": {},
-    "win10-x64-aot": {}
+    "win10-arm": { },
+    "win10-arm-aot": { },
+    "win10-x86": { },
+    "win10-x86-aot": { },
+    "win10-x64": { },
+    "win10-x64-aot": { }
   }
 }


### PR DESCRIPTION
I was having problems with GeoExtensions, that I could not even compile the project, so I made this "helper" to not depend of GeoExtensions.
It is a really necessary and vital change? No, but it's not a bad change.
The GeoHelper does exactly the same job, returning the same result in meters.
The GeoExtensions package is almost non used, and has a lot of unnecessary thing to PoGo.