### PR TITLE
HOT FIX

### DIFF
--- a/PokemonGo-UWP/PokemonGo-UWP.csproj
+++ b/PokemonGo-UWP/PokemonGo-UWP.csproj
@@ -591,6 +591,7 @@
     <Compile Include="Utils\Game\Converters.cs" />
     <Compile Include="Utils\Helpers\IStorageHelper.cs" />
     <Compile Include="Utils\Helpers\LiveTileHelper.cs" />
+    <Compile Include="Utils\Helpers\GeoHelper.сѕ" />
     <Compile Include="Utils\Helpers\LiveTileModes.cs" />
     <Compile Include="Utils\Helpers\LocalCacheHelper.cs" />
     <Compile Include="Utils\Helpers\StorageHelper.cs" />


### PR DESCRIPTION
#Fixes:

10:43:14 AM Entities\FortDataWrapper.cs(9,27): error CS0234: The type or a name of namespace "Helpers" doesn't exist in namespace of "PokemonGo_UWP.Utils" (perhaps, there is no reference to assembly). 

#Changes:

I have added the reference to helper GeoHelper

#Change details:

#Other informations:

