### PR TITLE
Aligned Achievement Titles

### DIFF
--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml
@@ -310,7 +310,7 @@
                                         <Viewbox Stretch="Uniform" 
                                                  x:Name="AchievementTypeText" 
                                                  MaxWidth="80"
-                                                 MaxHeight="20"
+                                                 Height="20"
                                                 Margin="0,5"
                                                  RelativePanel.AlignHorizontalCenterWithPanel="True">
                                             <TextBlock Text="{Binding Key, Converter={StaticResource AchievementTranslationConverter}}"


### PR DESCRIPTION
#Fixes:

- Aligned achievement titles

#Changes:

- N/A

#Change details:

The titles for achievements were misaligning the whole achievement depending on the length of the title.

#Other informations:
