### PR TITLE
Nearby + Pokedex Fixes

### DIFF
--- a/PokemonGo-UWP/Styles/Custom.xaml
+++ b/PokemonGo-UWP/Styles/Custom.xaml
@@ -1254,14 +1254,14 @@
     <Style TargetType="Image" x:Key="NearbyPokemonImageStyle">
         <Setter Property="Stretch" Value="Uniform"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
-        <Setter Property="Width" Value="36"/>
-        <Setter Property="Height" Value="36"/>
+        <!--<Setter Property="Width" Value="36"/>
+        <Setter Property="Height" Value="36"/>-->
     </Style>
     
     <Style TargetType="BitmapIcon" x:Key="NearbyPokemonBitmapIconStyle">
         <Setter Property="VerticalAlignment" Value="Center"/>
-        <Setter Property="Width" Value="36"/>
-        <Setter Property="Height" Value="36"/>
+        <!--<Setter Property="Width" Value="36"/>
+        <Setter Property="Height" Value="36"/>-->
     </Style>
 
     <Style TargetType="BitmapIcon" x:Key="NearbyPokemonNotInPokedexBitmapIconStyle" BasedOn="{StaticResource NearbyPokemonBitmapIconStyle}">

--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -23,6 +23,7 @@ using POGOProtos.Map.Fort;
 using POGOProtos.Map.Pokemon;
 using POGOProtos.Networking.Responses;
 using Template10.Common;
+using System.Collections.ObjectModel;
 
 namespace PokemonGo_UWP.Utils
 {
@@ -817,7 +818,7 @@ namespace PokemonGo_UWP.Utils
         #endregion
     }
 
-    public class NearbyPokemonInPokedexToStyleConverter : IValueConverter
+    public class NearbyPokemonInPokedexToVisibilityConverter : IValueConverter
     {
         #region Implementation of IValueConverter
 
@@ -825,17 +826,17 @@ namespace PokemonGo_UWP.Utils
         {
             // Get the Pokemon passed in. If it's null, you can't see the real deal.
             NearbyPokemonWrapper pokemon = value as NearbyPokemonWrapper;
-            if (pokemon == null) return (Style)App.Current.Resources["NearbyPokemonNotInPokedexBitmapIconStyle"];
+            if (pokemon == null) return Visibility.Collapsed;
 
             // Get the Pokedex entry for this Pokemon. If it's null, you can't see the real deal.
             var entry = GameClient.PokedexInventory.FirstOrDefault(c => c.PokemonId == pokemon.PokemonId);
-            if (entry == null) return (Style)App.Current.Resources["NearbyPokemonNotInPokedexBitmapIconStyle"];
+            if (entry == null) return Visibility.Collapsed;
 
             // Get the Pokedex entry for this Pokemon. If it's null, you can't see the real deal.
-            if (entry.TimesCaptured == 0) return (Style)App.Current.Resources["NearbyPokemonNotInPokedexBitmapIconStyle"];
+            if (entry.TimesCaptured == 0) return Visibility.Collapsed;
 
             // You've cleared all the reasons NOT to show it. So show it.
-            return (Style)App.Current.Resources["NearbyPokemonBitmapIconStyle"];
+            return Visibility.Visible;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)
@@ -951,7 +952,6 @@ namespace PokemonGo_UWP.Utils
 
         #endregion
     }
-
 
     public class PokemonSortingModesToSortingModesListConverter : IValueConverter
     {

--- a/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/GameMapPageViewModel.cs
@@ -38,16 +38,18 @@ namespace PokemonGo_UWP.ViewModels
                 var poke2 = new NearbyPokemon()
                 {
                     PokemonId = PokemonId.Arbok,
-                    DistanceInMeters = 10,
+                    DistanceInMeters = 11,
                 };
                 var poke3 = new NearbyPokemon()
                 {
                     PokemonId = PokemonId.Blastoise,
-                    DistanceInMeters = 10,
+                    DistanceInMeters = 12,
                 };
                 GameClient.NearbyPokemons.Add(new NearbyPokemonWrapper(poke1));
                 GameClient.NearbyPokemons.Add(new NearbyPokemonWrapper(poke2));
                 GameClient.NearbyPokemons.Add(new NearbyPokemonWrapper(poke3));
+                GameClient.PokedexInventory.Add(new PokedexEntry { PokemonId = poke1.PokemonId, TimesCaptured = 1 });
+                GameClient.PokedexInventory.Add(new PokedexEntry { PokemonId = poke2.PokemonId, TimesCaptured = 1 });
             }
         }
 

--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -164,7 +164,7 @@
                              Duration="0:0:0.2" />
         </Storyboard>
 
-        <utils:NearbyPokemonInPokedexToStyleConverter x:Key="NearbyPokemonInPokedexToStyleConverter" />
+        <utils:NearbyPokemonInPokedexToVisibilityConverter x:Key="NearbyPokemonInPokedexToVisibilityConverter" />
 
     </Page.Resources>
 
@@ -289,14 +289,25 @@
 
                                     <GridView.ItemTemplate>
                                         <DataTemplate>
-                                            <Image
-                                                Source="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
-                                                Stretch="Uniform"
-                                                Height="54"
-                                                Width="54"
-                                                VerticalAlignment="Center"
-                                                HorizontalAlignment="Center"
-                                                Margin="6,0" />
+                                            <Grid>
+                                                <Image Canvas.ZIndex="100"
+                                                       Source="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                                       Visibility="{Binding Converter={StaticResource NearbyPokemonInPokedexToVisibilityConverter}}"
+                                                       Height="60"
+                                                       Width="60"
+                                                       VerticalAlignment="Center"
+                                                       HorizontalAlignment="Center"
+                                                       Stretch="Uniform"
+                                                       Margin="6,0" />
+                                                
+                                                <BitmapIcon UriSource="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                                            Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}"
+                                                            Height="60"
+                                                            Width="60"
+                                                            VerticalAlignment="Center"
+                                                            HorizontalAlignment="Center"
+                                                            Margin="6,0" />
+                                            </Grid>
                                         </DataTemplate>
                                     </GridView.ItemTemplate>
                                 </GridView>
@@ -642,25 +653,100 @@
                                          Opacity="0.7" />
                     </Border.Background>
 
-                    <Grid HorizontalAlignment="Stretch">
+                    <GridView ItemsSource="{Binding NearbyPokemons}"
+                              HorizontalAlignment="Stretch"
+                              HorizontalContentAlignment="Stretch"
+                              SelectionMode="None" 
+                              ShowsScrollingPlaceholders="False" 
+                              IsMultiSelectCheckBoxEnabled="False" >
+
+                        <GridView.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapGrid Orientation="Horizontal"
+                                          VerticalChildrenAlignment="Top"
+                                          MaximumRowsOrColumns="10" 
+                                          ItemHeight="40" 
+                                          ItemWidth="52"
+                                          ScrollViewer.VerticalScrollBarVisibility="Disabled" />
+                            </ItemsPanelTemplate>
+                        </GridView.ItemsPanel>
+
+                        <GridView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="0,-4,0,0" Padding="6,0">
+                                    <Image Canvas.ZIndex="100"
+                                           Source="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                           Visibility="{Binding Converter={StaticResource NearbyPokemonInPokedexToVisibilityConverter}, UpdateSourceTrigger=PropertyChanged}"
+                                           VerticalAlignment="Center"
+                                           HorizontalAlignment="Center"
+                                           Stretch="Uniform"
+                                           Height="40"
+                                           Width="40"
+                                           Margin="0"/>
+
+                                    <BitmapIcon UriSource="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                                Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}"
+                                                VerticalAlignment="Center"
+                                                HorizontalAlignment="Center"
+                                                Height="36"
+                                                Width="36"
+                                                Margin="6,0" />
+                                </Grid>
+                            </DataTemplate>
+                        </GridView.ItemTemplate>
+                    </GridView>
+
+                    <!--<Grid HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
+                        <Image Grid.Column="0"
+                               Canvas.ZIndex="100"
+                                Source="{Binding NearbyPokemons[0].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                Visibility="{Binding NearbyPokemons[0], Converter={StaticResource NearbyPokemonInPokedexToVisibilityConverter}}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                Height="36"
+                                Width="36"
+                                Stretch="Uniform"/>
+
                         <BitmapIcon Grid.Column="0"
-                               UriSource="{Binding NearbyPokemons[0].ImageFilePath}"
-                               Style="{Binding Path=NearbyPokemons[0], Converter={StaticResource NearbyPokemonInPokedexToStyleConverter}}" />
+                                    Canvas.ZIndex="0"
+                               UriSource="{Binding NearbyPokemons[0].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                               Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}" />
+
+                        <Image Grid.Column="1"
+                               Canvas.ZIndex="100"
+                                Source="{Binding NearbyPokemons[1].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                Visibility="{Binding NearbyPokemons?[1], Converter={StaticResource NearbyPokemonInPokedexToVisibilityConverter}}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                Height="36"
+                                Width="36"
+                                Stretch="Uniform"/>
 
                         <BitmapIcon Grid.Column="1"
-                               UriSource="{Binding NearbyPokemons[1].ImageFilePath}"
-                               Style="{Binding Path=NearbyPokemons[1], Converter={StaticResource NearbyPokemonInPokedexToStyleConverter}}" />
+                               UriSource="{Binding NearbyPokemons[1].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                               Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}" />
+
+                        <Image Grid.Column="2"
+                               Canvas.ZIndex="100"
+                                Source="{Binding NearbyPokemons[2].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                Visibility="{Binding NearbyPokemons[2], Converter={StaticResource NearbyPokemonInPokedexToVisibilityConverter}}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                Height="36"
+                                Width="36"
+                                Stretch="Uniform"/>
 
                         <BitmapIcon Grid.Column="2"
-                               UriSource="{Binding NearbyPokemons[2].ImageFilePath}"
-                               Style="{Binding Path=NearbyPokemons[2], Converter={StaticResource NearbyPokemonInPokedexToStyleConverter}}" />
-                    </Grid>
+                               UriSource="{Binding NearbyPokemons[2].PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                               Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}" />
+                    </Grid>-->
+
                 </Border>
 
             </Border>

--- a/PokemonGo-UWP/Views/SettingsPage.xaml
+++ b/PokemonGo-UWP/Views/SettingsPage.xaml
@@ -91,7 +91,7 @@
                            VerticalAlignment="Center"
                            Margin="15,15,15,25" />
 
-                <CheckBox Grid.Row="3"
+                <CheckBox Grid.Row="2"
                           Grid.Column="1"
                           IsChecked="{Binding IsAutoRotateMapEnabled, Mode=TwoWay}"
                           Style="{StaticResource SettingsCheckbox}"


### PR DESCRIPTION
- Adjusted the converter logic to tweak visibility instead of styles.
- Changed the PokedexInventory collection to ObservableCollectionPlus, so that the CollectionChanged event could be handled to re-fire the Converters. (Handles https://github.com/ST-Apps/PoGo-UWP/pull/926#issuecomment-240239714)
- Fixed the layout for the "NearbyPokemon" window in the bottom corner of the map, so it will show more Pokemon on PCs and Tablets.
- Fixed a stupid bug in the Settings page where I overlapped checkboxes by mistake.