### PR TITLE
Achievment names in original app CAPITALIZED

### DIFF
--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -308,7 +308,7 @@ namespace PokemonGo_UWP.Utils
             var badgeType =
                 (BadgeTypeAttribute)fieldInfo.GetCustomAttributes(typeof(BadgeTypeAttribute), false).First();
 
-            return badgeType == null ? "" : Resources.Achievements.GetString(badgeType.Value.ToString());
+            return badgeType == null ? "" : Resources.Achievements.GetString(badgeType.Value.ToString()).ToUpper();
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
Minor Fix

#Other informations:

In original app achievment names are always CAPITALIZED.