### PR TITLE
Replace ItemsSource binding with manual insert

### DIFF
--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -94,7 +94,7 @@
                              To="350"
                              Duration="0:0:0.2" />
         </Storyboard>
-        
+
     </Page.Resources>
 
     <Grid>
@@ -164,7 +164,7 @@
                 <Image Source="../Assets/Buttons/btn_close_dark.png" />
             </Button>
         </Grid>
-        
+
         <Grid x:Name="IncubatorsContainer"
               Canvas.ZIndex="5">
             <Grid.RowDefinitions>
@@ -266,12 +266,11 @@
                         </StackPanel>
                         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Hidden">
                             <GridView x:Name="PokemonInventoryGridView"
-                                      ItemsSource="{x:Bind ViewModel.PokemonInventory}"
                                       SelectionMode="None"
                                       Padding="0,0,0,57.5"
                                       ShowsScrollingPlaceholders="True"
                                       SizeChanged="GridViewPokemonSizeChanged">
-                                
+
                                 <GridView.ItemTemplate>
                                     <DataTemplate x:DataType="entities:PokemonDataWrapper">
                                         <StackPanel HorizontalAlignment="Center" 
@@ -340,7 +339,7 @@
                                       SelectionMode="None"
                                       Padding="0,0,0,57.5"
                                       SizeChanged="GridViewEggsSizeChanged">
-                                
+
                                 <GridView.ItemTemplate>
                                     <DataTemplate x:DataType="entities:PokemonDataWrapper">
                                         <StackPanel HorizontalAlignment="Center" 

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
@@ -27,7 +27,8 @@ namespace PokemonGo_UWP.Views
 									HideIncubatorsModalAnimation.To = IncubatorsModal.ActualHeight;
 				HideIncubatorsModalStoryboard.Completed += (ss, ee) => { IncubatorsModal.IsModal = false; };
 
-                foreach(var pokemon in ViewModel.PokemonInventory)
+			    PokemonInventoryGridView.Items.Clear();
+                foreach (var pokemon in ViewModel.PokemonInventory)
                 {
                     PokemonInventoryGridView.Items.Add(pokemon);
                     PokemonInventoryGridView.UpdateLayout();

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
@@ -26,7 +26,13 @@ namespace PokemonGo_UWP.Views
 				ShowIncubatorsModalAnimation.From =
 									HideIncubatorsModalAnimation.To = IncubatorsModal.ActualHeight;
 				HideIncubatorsModalStoryboard.Completed += (ss, ee) => { IncubatorsModal.IsModal = false; };
-			};
+
+                foreach(var pokemon in ViewModel.PokemonInventory)
+                {
+                    PokemonInventoryGridView.Items.Add(pokemon);
+                    PokemonInventoryGridView.UpdateLayout();
+                }
+            };
 		}
 
 		private void ToggleIncubatorModel(object sender, TappedRoutedEventArgs e)


### PR DESCRIPTION
#Fixes:
- Fix #936

#Changes:
- Remove PokemonInventory Binding from xaml's GridView
- Add manual addition via foreach in PokemonInventoryPage's Loaded event

#Change details:
When ItemsSource changes with large amount of items it creates Layout Cycle Exception. When adding manually and UpdatingLayout in the meantime, it doesn't create that Exception. (more info: http://codezero.one/Details_mobile?d=1567&z=1&t=UWP+Error%3A+layout+cycle+detected )

#Other informations:
I don't know how to do this in Bindings, if it is even possible. If it is, please could you guide me to it and I will update this PR.