### PR TITLE
Fix sign in issues

### DIFF
--- a/PokemonGo-UWP/Utils/GameClient.cs
+++ b/PokemonGo-UWP/Utils/GameClient.cs
@@ -96,7 +96,7 @@ namespace PokemonGo_UWP.Utils
                 }
                 else
                 {
-                    // Check if we need to update                
+                    // Check if we need to update
                     var minSeconds = GameSetting.MapSettings.GetMapObjectsMinRefreshSeconds;
                     var maxSeconds = GameSetting.MapSettings.GetMapObjectsMaxRefreshSeconds;
                     var minDistance = GameSetting.MapSettings.GetMapObjectsMinDistanceMeters;
@@ -121,7 +121,7 @@ namespace PokemonGo_UWP.Utils
                             canRefresh = true;
                         }
                     }
-                } 
+                }
                 // Update!
                 if (!canRefresh)
                 {
@@ -331,7 +331,7 @@ namespace PokemonGo_UWP.Utils
         #region Login/Logout
 
         /// <summary>
-        /// Saves the new AccessToken to settings.        
+        /// Saves the new AccessToken to settings.
         /// </summary>
         private static void SaveAccessToken()
         {
@@ -371,7 +371,7 @@ namespace PokemonGo_UWP.Utils
             _client = new Client(_clientSettings, null, DeviceInfos.Instance) {AccessToken = LoadAccessToken()};
             var apiFailureStrategy = new ApiFailureStrategy(_client);
             _client.ApiFailure = apiFailureStrategy;
-            // Register to AccessTokenChanged       
+            // Register to AccessTokenChanged
             apiFailureStrategy.OnAccessTokenUpdated += (s, e) => SaveAccessToken();
             try
             {
@@ -408,7 +408,7 @@ namespace PokemonGo_UWP.Utils
             _client = new Client(_clientSettings, null, DeviceInfos.Instance);
             var apiFailureStrategy = new ApiFailureStrategy(_client);
             _client.ApiFailure = apiFailureStrategy;
-            // Register to AccessTokenChanged       
+            // Register to AccessTokenChanged
             apiFailureStrategy.OnAccessTokenUpdated += (s, e) => SaveAccessToken();
             // Get PTC token
             await _client.Login.DoLogin();
@@ -441,7 +441,7 @@ namespace PokemonGo_UWP.Utils
             _client = new Client(_clientSettings, null, DeviceInfos.Instance);
             var apiFailureStrategy = new ApiFailureStrategy(_client);
             _client.ApiFailure = apiFailureStrategy;
-            // Register to AccessTokenChanged       
+            // Register to AccessTokenChanged
             apiFailureStrategy.OnAccessTokenUpdated += (s, e) => SaveAccessToken();
             // Get Google token
             await _client.Login.DoLogin();
@@ -466,12 +466,13 @@ namespace PokemonGo_UWP.Utils
             if (!SettingsService.Instance.RememberLoginData)
                 SettingsService.Instance.UserCredentials = null;
             _heartbeat?.StopDispatcher();
-            _geolocator.PositionChanged -= GeolocatorOnPositionChanged;
+            if(_geolocator != null)
+                _geolocator.PositionChanged -= GeolocatorOnPositionChanged;
             _geolocator = null;
             _lastGeopositionMapObjectsRequest = null;
-            CatchablePokemons.Clear();
-            NearbyPokemons.Clear();
-            NearbyPokestops.Clear();
+            CatchablePokemons?.Clear();
+            NearbyPokemons?.Clear();
+            NearbyPokestops?.Clear();
         }
 
         #endregion
@@ -632,7 +633,7 @@ namespace PokemonGo_UWP.Utils
                         <GetMapObjectsResponse, GetHatchedEggsResponse, GetInventoryResponse, CheckAwardedBadgesResponse,
                             DownloadSettingsResponse>> GetMapObjects(Geoposition geoposition)
         {
-            _lastGeopositionMapObjectsRequest = geoposition;      
+            _lastGeopositionMapObjectsRequest = geoposition;
             return await _client.Map.GetMapObjects();
         }
 
@@ -683,7 +684,7 @@ namespace PokemonGo_UWP.Utils
                 var levelUpResponse = await GetLevelUpRewards(tmpStats.Level);
                 return levelUpResponse;
             }
-            PlayerStats = tmpStats;            
+            PlayerStats = tmpStats;
             return null;
         }
 
@@ -782,7 +783,7 @@ namespace PokemonGo_UWP.Utils
             PokemonsInventory.AddRange(fullInventory.Select(item => item.InventoryItemData.PokemonData)
                 .Where(item => item != null && item.PokemonId > 0), true);
             EggsInventory.AddRange(fullInventory.Select(item => item.InventoryItemData.PokemonData)
-                .Where(item => item != null && item.IsEgg), true);            
+                .Where(item => item != null && item.IsEgg), true);
 
             // Update candies
             CandyInventory.AddRange(from item in fullInventory

--- a/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
@@ -122,6 +122,10 @@ namespace PokemonGo_UWP.ViewModels
             _doPtcLoginCommand = new DelegateCommand(async () =>
             {
                 Busy.SetBusy(true, Resources.CodeResources.GetString("LoggingInText"));
+
+                //Let's hack the shit out of SetBusy, it didn't want to populate itself, so we will HELP IT!
+                await Task.Delay(50);
+
                 try
                 {
                     var loginSuccess = await GameClient.DoPtcLogin(Username, Password);
@@ -178,6 +182,10 @@ namespace PokemonGo_UWP.ViewModels
             _doGoogleLoginCommand = new DelegateCommand(async () =>
             {
                 Busy.SetBusy(true, Resources.CodeResources.GetString("LoggingInText"));
+
+                //Let's hack the shit out of SetBusy, it didn't want to populate itself, so we will HELP IT!
+                await Task.Delay(50);
+
                 try
                 {
                     if (!await GameClient.DoGoogleLogin(Username.Trim(), Password.Trim()))

--- a/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Xaml.Navigation;
+using Microsoft.HockeyApp;
 using PokemonGo.RocketAPI.Exceptions;
 using PokemonGo_UWP.Utils;
 using PokemonGo_UWP.Views;
@@ -165,6 +166,12 @@ namespace PokemonGo_UWP.ViewModels
                     if (e.Message.Contains("Your username or password is incorrect."))
                     {
                         await new MessageDialog(e.Message).ShowAsyncQueue();
+                    }
+                    else
+                    {
+                        //TODO: Message that contains, that Developers working on fix (it means that server is probably down) - can't reproduce
+
+                        HockeyClient.Current.TrackException(e);
                     }
                 }
                 finally

--- a/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Popups;
@@ -30,7 +31,7 @@ namespace PokemonGo_UWP.ViewModels
             NavigationService.ClearHistory();
             if (suspensionState.Any())
             {
-                // Recovering the state                
+                // Recovering the state
                 Username = (string) suspensionState[nameof(Username)];
                 Password = (string) suspensionState[nameof(Password)];
             }
@@ -112,7 +113,7 @@ namespace PokemonGo_UWP.ViewModels
 
         #endregion
 
-        #region Game Logic        
+        #region Game Logic
 
         private DelegateCommand _doPtcLoginCommand;
 
@@ -152,9 +153,19 @@ namespace PokemonGo_UWP.ViewModels
                         JToken token = json.SelectToken("$.errors[0]");
                         if (token != null)
                             errorMessage = token.ToString();
-                    } catch { }
+                    }
+                    catch
+                    {
+                    }
 
                     await new MessageDialog(errorMessage).ShowAsyncQueue();
+                }
+                catch (Exception e)
+                {
+                    if (e.Message.Contains("Your username or password is incorrect."))
+                    {
+                        await new MessageDialog(e.Message).ShowAsyncQueue();
+                    }
                 }
                 finally
                 {

--- a/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/LoginPageViewModel.cs
@@ -145,13 +145,13 @@ namespace PokemonGo_UWP.ViewModels
                 }
                 catch (LoginFailedException e)
                 {
-                    string errorMessage = Resources.CodeResources.GetString("LoginFailedText");
+                    var errorMessage = Resources.CodeResources.GetString("LoginFailedText");
 
                     try
                     {
-                        Task<string> result = e.GetLoginResponseContentAsString();
-                        JObject json = JObject.Parse(result.Result);
-                        JToken token = json.SelectToken("$.errors[0]");
+                        var result = e.GetLoginResponseContentAsString();
+                        var json = JObject.Parse(result.Result);
+                        var token = json.SelectToken("$.errors[0]");
                         if (token != null)
                             errorMessage = token.ToString();
                     }
@@ -163,16 +163,7 @@ namespace PokemonGo_UWP.ViewModels
                 }
                 catch (Exception e)
                 {
-                    if (e.Message.Contains("Your username or password is incorrect."))
-                    {
-                        await new MessageDialog(e.Message).ShowAsyncQueue();
-                    }
-                    else
-                    {
-                        //TODO: Message that contains, that Developers working on fix (it means that server is probably down) - can't reproduce
-
-                        HockeyClient.Current.TrackException(e);
-                    }
+                    HockeyClient.Current.TrackEvent(e.Message);
                 }
                 finally
                 {

--- a/PokemonGoAPI/Login/PtcLogin.cs
+++ b/PokemonGoAPI/Login/PtcLogin.cs
@@ -78,7 +78,12 @@ namespace PokemonGo.RocketAPI.Login
             var loginResponseData = JObject.Parse(loginResponseDataRaw);
             var loginResponseErrors = (JArray)loginResponseData["errors"];
 
-            throw new Exception($"Pokemon Trainer Club gave error(s): '{string.Join(",", loginResponseErrors)}'");
+            var errorMessages = string.Join(",", loginResponseErrors);
+            if (errorMessages.Contains("Your username or password is incorrect.") ||
+                errorMessages.Contains("As a security measure, your account has been disabled"))
+                throw new LoginFailedException(loginResponse);
+
+            throw new Exception($"Pokemon Trainer Club gave error(s): '{errorMessages}'");
         }
 
         /// <summary>
@@ -130,7 +135,7 @@ namespace PokemonGo.RocketAPI.Login
                 var ticket = PostLogin(tempHttpClient, _username, _password, loginData);
                 var accessToken = PostLoginOauth(tempHttpClient, ticket);
                 accessToken.Username = _username;
-                await Task.CompletedTask;            
+                await Task.CompletedTask;
                 return accessToken;
             }
         }


### PR DESCRIPTION
# Fixes:
N/A (or not found any)

# Changes:
- Add correct exception handling when username or password is incorrect
- Add checks on DoLogout, because when "something went wrong" on login screen happens, then it tries to logout with not initialized GameClient

# Change details:
Previous implementation doesn't work:
```
catch (LoginFailedException e)
```
because PokemonGoAPI throws it as this:
```
throw new Exception($"Pokemon Trainer Club gave error(s): '{string.Join(",", loginResponseErrors)}'");
```
So now, I handle it like this:
```
                catch (Exception e)
                {
                    if (e.Message.Contains("Your username or password is incorrect."))
                    {
```
because the Message is:
```
Message = "Pokemon Trainer Club gave error(s): 'Your username or password is incorrect. You have 3 attempts left before you will be locked out of your account for 15 minutes.'"
```

# Other informations:
- The previous implementation should stay when PokemonGoAPI fixes this, but we can have this fallback.
- Also I added HockeyApp tracing of login issues because I saw another message, when servers are down, but can't reproduce and don't know what message to look for.