### PR TITLE
Add memory for navigating back to pokelist

### DIFF
--- a/PokemonGo-UWP/Entities/PokemonDataWrapper.cs
+++ b/PokemonGo-UWP/Entities/PokemonDataWrapper.cs
@@ -49,6 +49,7 @@ namespace PokemonGo_UWP.Entities
             _gotoPokemonDetailsCommand = new DelegateCommand(() =>
             {
                 NavigationHelper.NavigationState["CurrentPokemon"] = this;
+                NavigationHelper.NavigationState["LastSelectedID"] = Id;
                 BootStrapper.Current.NavigationService.Navigate(typeof(PokemonDetailPage));
             }, () => true));
 

--- a/PokemonGo-UWP/ViewModels/PokemonInventoryPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokemonInventoryPageViewModel.cs
@@ -23,6 +23,15 @@ namespace PokemonGo_UWP.ViewModels
         ///     Egg selected for incubation
         /// </summary>
         private PokemonData _selectedEgg;
+        private int _lastVisibleIndex;
+
+        public int LastVisibleIndex
+        {
+            get { return Utilities.EnsureRange(_lastVisibleIndex, 0, PokemonInventory.Count); }
+            set { _lastVisibleIndex = value; }
+        }
+
+        public Action ResetView;
 
         #endregion
 
@@ -57,7 +66,7 @@ namespace PokemonGo_UWP.ViewModels
                                                               .OrderBy(c => c.EggKmWalkedTarget);
                 var incubatedEggs = GameClient.EggsInventory.Where(o => !string.IsNullOrEmpty(o.EggIncubatorId))
                                                               .OrderBy(c => c.EggKmWalkedTarget);
-                EggsInventory.Clear();                
+                EggsInventory.Clear();
                 // advancedrei: I have verified this is the sort order in the game.
                 foreach (var incubatedEgg in incubatedEggs)
                 {
@@ -69,6 +78,9 @@ namespace PokemonGo_UWP.ViewModels
                 {
                     EggsInventory.Add(new PokemonDataWrapper(pokemonData));
                 }
+
+                if(mode == NavigationMode.Back)
+                    ResetView?.Invoke();
             }
 
             await Task.CompletedTask;
@@ -163,6 +175,7 @@ namespace PokemonGo_UWP.ViewModels
 
         #region Pokemon Inventory Handling
 
+
         private void UpdateSorting()
         {
             PokemonInventory =
@@ -187,10 +200,10 @@ namespace PokemonGo_UWP.ViewModels
                     return pokemonInventory.OrderByDescending(pokemon => pokemon.CreationTimeMs);
                 case PokemonSortingModes.Fav:
                     return pokemonInventory.OrderByDescending(pokemon => pokemon.Favorite)
-                         .ThenByDescending(pokemon => pokemon.Cp); 
+                         .ThenByDescending(pokemon => pokemon.Cp);
                 case PokemonSortingModes.Number:
                     return pokemonInventory.OrderBy(pokemon => pokemon.PokemonId)
-                         .ThenByDescending(pokemon => pokemon.Cp); 
+                         .ThenByDescending(pokemon => pokemon.Cp);
                 case PokemonSortingModes.Health:
                     return pokemonInventory.OrderByDescending(pokemon => pokemon.Stamina)
                         .ThenByDescending(pokemon => pokemon.Cp);

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -396,27 +396,34 @@
                                              IsIndeterminate="False"
                                              HorizontalAlignment="Center" />
 
-                                <TextBlock Style="{StaticResource TextGridViewTop}">
-                                   <Run Text="{Binding EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.#\}}" />
-                                   <Run Text="/" />
-                                   <Run FontWeight="Bold"
-                                        Text="{Binding EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0\}}" />
-                                   <Run FontWeight="Bold"
-                                        Text="km" />
-                                </TextBlock>
-                             </StackPanel>
-                          </DataTemplate>
-                       </GridView.ItemTemplate>
-                    </GridView>
-                    <Button x:Name="IncubatorButton" Grid.Row="1"
-                            Style="{StaticResource ButtonCircleBigInverse}"
-                            Tapped="ToggleIncubatorModel"
-                            Margin="16">
-                       <Image Source="../Assets/Buttons/btn_incubator_dark.png" />
-                    </Button>
-                 </Grid>
-              </PivotItem>
-           </Pivot>
+                                        <TextBlock Style="{StaticResource TextGridViewTop}">
+                                                <Run
+                                                    Text="{x:Bind EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.#\}}"
+                                                    x:Phase="0" />
+                                                <Run Text="/" />
+                                                <Run FontWeight="Bold"
+                                                     Text="{x:Bind EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0\}}"
+                                                     x:Phase="0" />
+                                                <Run FontWeight="Bold"
+                                                     Text="km" />
+                                        </TextBlock>
+
+                                    </StackPanel>
+                                </DataTemplate>
+                            </GridView.ItemTemplate>
+                        </GridView>
+
+                        <Button x:Name="IncubatorButton" Grid.Row="1"
+                                Style="{StaticResource ButtonCircleBigInverse}"
+                                Tapped="ToggleIncubatorModel"
+                                Margin="16">
+                            <Image Source="../Assets/Buttons/btn_incubator_dark.png" />
+                        </Button>
+
+                    </Grid>
+                </PivotItem>
+
+            </Pivot>
         </Border>
 
         <Button Command="{Binding ReturnToGameScreen}"

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
 using PokemonGo_UWP.Entities;
 using PokemonGo_UWP.Utils;
+using Template10.Services.NavigationService;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -66,14 +67,19 @@ namespace PokemonGo_UWP.Views
 			base.OnNavigatingFrom(e);
 			SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
 
-            var lastSelectedId = (ulong)NavigationHelper.NavigationState["LastSelectedID"];
+		    if (NavigationHelper.NavigationState.ContainsKey("LastSelectedID"))
+		    {
+		        var lastSelectedId = (ulong) NavigationHelper.NavigationState["LastSelectedID"];
 
-		    var pokemonList = ViewModel.PokemonInventory;
-            var pokemon = pokemonList
-                .FirstOrDefault(i => i.Id == lastSelectedId);
-            var index = pokemonList
-                .IndexOf(pokemon);
-		    ViewModel.LastVisibleIndex = index;
+		        var pokemonList = ViewModel.PokemonInventory;
+		        var pokemon = pokemonList
+		            .FirstOrDefault(i => i.Id == lastSelectedId);
+		        var index = pokemonList
+		            .IndexOf(pokemon);
+		        ViewModel.LastVisibleIndex = index;
+		    }
+		    else
+                ViewModel.LastVisibleIndex = 0;
 		}
 
         private void OnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
@@ -1,17 +1,21 @@
-﻿using Windows.UI.Core;
+﻿using System.Collections.ObjectModel;
+using System.Linq;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
+using PokemonGo_UWP.Entities;
+using PokemonGo_UWP.Utils;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
 namespace PokemonGo_UWP.Views
 {
-	/// <summary>
-	///     An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	public sealed partial class PokemonInventoryPage : Page
+    /// <summary>
+    ///     An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class PokemonInventoryPage : Page
 	{
 		public PokemonInventoryPage()
 		{
@@ -27,9 +31,16 @@ namespace PokemonGo_UWP.Views
 									HideIncubatorsModalAnimation.To = IncubatorsModal.ActualHeight;
 				HideIncubatorsModalStoryboard.Completed += (ss, ee) => { IncubatorsModal.IsModal = false; };
 			};
+
+		    ViewModel.ResetView +=
+		        () =>
+		        {
+		            if (ViewModel.PokemonInventory != null && ViewModel.PokemonInventory.Count > 0)
+		                PokemonInventoryGridView?.ScrollIntoView(ViewModel.PokemonInventory[ViewModel.LastVisibleIndex]);
+		        };
 		}
 
-		private void ToggleIncubatorModel(object sender, TappedRoutedEventArgs e)
+        private void ToggleIncubatorModel(object sender, TappedRoutedEventArgs e)
 		{
 			if (IncubatorsModal.IsModal)
 			{
@@ -50,22 +61,31 @@ namespace PokemonGo_UWP.Views
 			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
 		}
 
-		private void OnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
-		{
-			if (!(SortMenuPanel.Opacity > 0)) return;
-			backRequestedEventArgs.Handled = true;
-			HideSortMenuStoryboard.Begin();
-		}
-
 		protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
 		{
 			base.OnNavigatingFrom(e);
 			SystemNavigationManager.GetForCurrentView().BackRequested -= OnBackRequested;
+
+            var lastSelectedId = (ulong)NavigationHelper.NavigationState["LastSelectedID"];
+
+		    var pokemonList = ViewModel.PokemonInventory;
+            var pokemon = pokemonList
+                .FirstOrDefault(i => i.Id == lastSelectedId);
+            var index = pokemonList
+                .IndexOf(pokemon);
+		    ViewModel.LastVisibleIndex = index;
 		}
 
-		#endregion
+        private void OnBackRequested(object sender, BackRequestedEventArgs backRequestedEventArgs)
+        {
+            if (!(SortMenuPanel.Opacity > 0)) return;
+            backRequestedEventArgs.Handled = true;
+            HideSortMenuStoryboard.Begin();
+        }
 
-		private void SelectionChanged(object sender, SelectionChangedEventArgs e)
+        #endregion
+
+        private void SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 
 			//SortingButton.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
@@ -100,6 +120,5 @@ namespace PokemonGo_UWP.Views
 				panel_threads.ItemWidth = e.NewSize.Width / 4;
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
# Changes:
- Add memory for navigating back to pokelist

# Change details:
- First Making it via SelectedItem didn't work.
- When you navigate back from pokemon detail or from pokemon transfer, you will end up having latest place of that pokemon on the bottom of the viewable screen. So it's perfect for "Pidgey Spam".
- When you navigate from GameMap, you will end up at the top.
- When you change ordering, you will end up at the top.
- It should be bullet-proof, no crashes allowed!! :)
- I haven't tested anything else (Is there anything else regarding pokelist?)

# Other informations:
I was drowning for 7 hours before I got the right idea, how to make it. So if it is not elegant, I would like to see you drowning for 7 hours before actually making it. :D
