### PR TITLE
Missing ; compile bug and protection level access for media

### DIFF
--- a/PokemonGo-UWP/Utils/Helpers/AudioUtils.cs
+++ b/PokemonGo-UWP/Utils/Helpers/AudioUtils.cs
@@ -8,8 +8,8 @@ namespace PokemonGo_UWP.Utils
 {
     public static class AudioUtils
     {
-        private static readonly MediaElement NormalSounds = new MediaElement();
-        private static readonly MediaElement CaptureSound = new MediaElement();
+        public static MediaElement NormalSounds = new MediaElement();
+        public static MediaElement CaptureSound = new MediaElement();
         private static bool _isPlaying;
 
         public static async Task PlaySound(string asset)

--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
@@ -7,7 +7,7 @@ using Windows.System.Threading;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using PokemonGo_UWP.Utils
+using PokemonGo_UWP.Utils;
 using Windows.UI.Xaml.Navigation;
 using PokemonGo.RocketAPI;
 using Template10.Common;


### PR DESCRIPTION
### Fixes:

- Fixed a compiling bug with the AudioHelper where the media file was inaccessible due to its protection level.
- Added a missing ; in CapturePokemonPage.xaml.cs

### Changes:

- N/A

### Change details:


- N/A

### Other informations:


- N/A