### PR TITLE
Rounded Progressbars + Fixed profile progressbar to color change according to the team color

### DIFF
--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml
@@ -207,7 +207,7 @@
                                                      Foreground="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
                                                      HorizontalAlignment="Stretch"
                                                      Margin="48,0"
-                                                     BorderBrush="Black"
+                                                     BorderBrush="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
                                                      BorderThickness="1"
                                                      Height="7"
                                                      x:Name="ExperienceProgressBar" />

--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml
@@ -203,10 +203,13 @@
 
                                         <ProgressBar Value="{Binding PlayerStats, Converter={StaticResource PlayerDataToCurrentExperienceConverter}}"
                                                      Maximum="{Binding PlayerStats, Converter={StaticResource PlayerDataToTotalLevelExperienceConverter}}"
-                                                     Foreground="#15E8DB"
+                                                     Style="{StaticResource ExperienceProgressbarStyle}"
+                                                     Foreground="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
                                                      HorizontalAlignment="Stretch"
-                                                     Height="8"
                                                      Margin="48,0"
+                                                     BorderBrush="Black"
+                                                     BorderThickness="1"
+                                                     Height="7"
                                                      x:Name="ExperienceProgressBar" />
 
                                         <StackPanel Orientation="Horizontal"
@@ -232,7 +235,7 @@
                                         </StackPanel>
 
                                         <Rectangle Fill="LightGray" Margin="0,20" Height="2"/>
-
+                                        
                                         <Grid x:Name="InformationGrid">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition />
@@ -261,14 +264,14 @@
                                                            Text="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamNameConverter}}" />
                                             </StackPanel>
                                         </Grid>
-                                        
+
                                     </StackPanel>
                                     
                                 </Grid>
                             </RelativePanel>
 
                             <Rectangle Fill="LightGray" Margin="20,2" Height="2"/>
-
+                            
                             <RelativePanel x:Name="InventoryUIPanel"
                                            RelativePanel.AlignTopWithPanel="True"
                                            RelativePanel.AlignLeftWithPanel="True"

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -385,21 +385,16 @@
 
                                 <StackPanel VerticalAlignment="Bottom">
 
-                                    <Border CornerRadius="2"
-                                            Width="200"
-                                            BorderBrush="#7EDAB5"
-                                            BorderThickness="1">
-
-                                        <ProgressBar Value="{Binding CurrentPokemon.Stamina, Mode=TwoWay}"
-                                                     Width="200"
-                                                     Maximum="{Binding CurrentPokemon.StaminaMax}"
-                                                     Foreground="#6BEFB6"
-                                                     IsIndeterminate="False"
-                                                     HorizontalAlignment="Center"
-                                                     HorizontalContentAlignment="Center"
-                                                     VerticalAlignment="Center" />
-
-                                    </Border>
+                                    <ProgressBar Value="{Binding CurrentPokemon.Stamina, Mode=TwoWay}"
+                                                 Width="200"
+                                                 Maximum="{Binding CurrentPokemon.StaminaMax}"
+                                                 Style="{StaticResource ExperienceProgressbarStyle}"
+                                                 HorizontalAlignment="Stretch"
+                                                 Margin="48,0"
+                                                 BorderBrush="Black"
+                                                 BorderThickness="1"
+                                                 Height="7"
+                                                 Foreground="#6BEFB6" />
 
                                     <TextBlock Margin="0,5"
                                                Foreground="#626264"
@@ -699,7 +694,7 @@
                                         <Grid HorizontalAlignment="Right"
                                               VerticalAlignment="Center">
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="60" />
+                                                <ColumnDefinition Width="70" />
                                             </Grid.ColumnDefinitions>
 
                                             <StackPanel Grid.Column="0"

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -391,7 +391,7 @@
                                                  Style="{StaticResource ExperienceProgressbarStyle}"
                                                  HorizontalAlignment="Stretch"
                                                  Margin="48,0"
-                                                 BorderBrush="Black"
+                                                 BorderBrush="#6BEFB6"
                                                  BorderThickness="1"
                                                  Height="7"
                                                  Foreground="#6BEFB6" />

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -309,6 +309,9 @@
                                         <ProgressBar
                                                 Value="{x:Bind Stamina}"
                                                 Maximum="{x:Bind StaminaMax}"
+                                                Style="{StaticResource ExperienceProgressbarStyle}"
+                                                BorderBrush="Black"
+                                                BorderThickness="1"
                                                 Margin="0,5"
                                                 Foreground="#6ee8b7"
                                                 IsIndeterminate="False"

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -310,7 +310,7 @@
                                                 Value="{x:Bind Stamina}"
                                                 Maximum="{x:Bind StaminaMax}"
                                                 Style="{StaticResource ExperienceProgressbarStyle}"
-                                                BorderBrush="Black"
+                                                BorderBrush="#6ee8b7"
                                                 BorderThickness="1"
                                                 Margin="0,5"
                                                 Foreground="#6ee8b7"


### PR DESCRIPTION
### Fixes:

- Color change in profile experience progressbar according to the team color
- The way to round the progress bar in pokémon detail page
- In the detail page of pokémons, corrected a small "lack of space" when 100 candys are required to evolve

### Changes:

- Roundend pregressbar in profile
- Roundend pregressbar in Pokémons list

![Imgur](http://i.imgur.com/9PpM6fu.png?2)
![Imgur](http://i.imgur.com/sIWczPP.png?1)
![Imgur](http://i.imgur.com/pGxdCLb.png?1)