### PR TITLE
Styles of Pokemon HP and Player XP

### DIFF
--- a/PokemonGo-UWP/Styles/Custom.xaml
+++ b/PokemonGo-UWP/Styles/Custom.xaml
@@ -1310,18 +1310,18 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ProgressBar">
                     <Grid Height="{TemplateBinding Height}"
-                              Width="{TemplateBinding Width}"
-                              MinWidth="50" >
+                          Width="{TemplateBinding Width}"
+                          MinWidth="50" >
                         <Border x:Name="ProgressBarTrack" 
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="2" >
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="2" >
                             <Border.Background>
                                 <SolidColorBrush Color="Black"
-                                                     Opacity="0.4" />
+                                                 Opacity="0.4" />
                             </Border.Background>
                             <Border.BorderBrush>
                                 <SolidColorBrush Color="Black"
-                                                     Opacity="0.4" />
+                                                 Opacity="0.4" />
                             </Border.BorderBrush>
 
                             <Border Background="{TemplateBinding Foreground}"
@@ -1329,6 +1329,49 @@
                                     HorizontalAlignment="Left"
                                     x:Name="ProgressBarIndicator"/>
                         </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ProgressBar" x:Name="PlayerProfileExperienceProgressBarStyle">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ProgressBar">
+                    <Grid x:Name="ProgressBar"
+                          MinHeight="7"
+                          MinWidth="50" >
+                        <Border x:Name="ProgressBarTrack" 
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Height="3"
+                                VerticalAlignment="Center"
+                                CornerRadius="2" >
+                            <Border.Background>
+                                <SolidColorBrush Color="Black"
+                                                 Opacity="0.2" />
+                            </Border.Background>
+                            <Border.BorderBrush>
+                                <SolidColorBrush Color="{TemplateBinding BorderBrush}"
+                                                 Opacity="0.2" />
+                            </Border.BorderBrush>
+                        </Border>
+
+                        <Grid x:Name="ProgressBarIndicator"
+                              VerticalAlignment="Center"
+                              HorizontalAlignment="Left">
+                            
+                            <Border Background="{TemplateBinding Foreground}"
+                                    CornerRadius="2"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Stretch"
+                                    Height="3" />
+                            
+                            <Ellipse Width="7" Height="7" 
+                                     Fill="{TemplateBinding Foreground}" 
+                                     Margin="-4,0,0,0"
+                                     HorizontalAlignment="Right"/>
+                        </Grid>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/PokemonGo-UWP/Styles/Custom.xaml
+++ b/PokemonGo-UWP/Styles/Custom.xaml
@@ -1378,6 +1378,36 @@
         </Setter>
     </Style>
 
+    <Style TargetType="ProgressBar" x:Name="PokemonHPProgressBarStyle">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ProgressBar">
+                    <Grid Height="{TemplateBinding Height}"
+                          Width="{TemplateBinding Width}"
+                          MinWidth="50" >
+                        <Border x:Name="ProgressBarTrack" 
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="1" >
+                            <Border.Background>
+                                <SolidColorBrush Color="Black"
+                                                 Opacity="0.2" />
+                            </Border.Background>
+                            <Border.BorderBrush>
+                                <SolidColorBrush Color="Black"
+                                                 Opacity="0.2" />
+                            </Border.BorderBrush>
+
+                            <Border Background="{TemplateBinding Foreground}"
+                                    CornerRadius="1"
+                                    HorizontalAlignment="Left"
+                                    x:Name="ProgressBarIndicator"/>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="Image" x:Key="NearbyPokemonImageStyle">
         <Setter Property="Stretch" Value="Uniform"/>
         <Setter Property="VerticalAlignment" Value="Center"/>

--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -696,6 +696,7 @@
                              Value="{Binding PlayerStats, Converter={StaticResource PlayerDataToCurrentExperienceConverter}, Mode=TwoWay}"
                              Maximum="{Binding PlayerStats, Converter={StaticResource PlayerDataToTotalLevelExperienceConverter}}"
                              Foreground="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
+                             Background="Black"
                              Height="5"
                              Margin="0,-5,0,0"
                              RelativePanel.AlignLeftWithPanel="True"

--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml
@@ -203,12 +203,12 @@
 
                                         <ProgressBar Value="{Binding PlayerStats, Converter={StaticResource PlayerDataToCurrentExperienceConverter}}"
                                                      Maximum="{Binding PlayerStats, Converter={StaticResource PlayerDataToTotalLevelExperienceConverter}}"
-                                                     Style="{StaticResource ExperienceProgressbarStyle}"
+                                                     Style="{StaticResource PlayerProfileExperienceProgressBarStyle}"
                                                      Foreground="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
                                                      HorizontalAlignment="Stretch"
                                                      Margin="48,0"
-                                                     BorderBrush="{Binding PlayerProfile.Team, Converter={StaticResource PlayerTeamToTeamColorBrushConverter}}"
-                                                     BorderThickness="1"
+                                                     Background="Black"
+                                                     BorderThickness="0"
                                                      Height="7"
                                                      x:Name="ExperienceProgressBar" />
 

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -608,11 +608,9 @@
                                     <ProgressBar Value="{Binding CurrentPokemon.Stamina, Mode=TwoWay}"
                                                  Width="200"
                                                  Maximum="{Binding CurrentPokemon.StaminaMax}"
-                                                 Style="{StaticResource ExperienceProgressbarStyle}"
+                                                 Style="{StaticResource PokemonHPProgressBarStyle}"
                                                  HorizontalAlignment="Stretch"
                                                  Margin="48,0"
-                                                 BorderBrush="#6BEFB6"
-                                                 BorderThickness="1"
                                                  Height="7"
                                                  Foreground="#6BEFB6" />
 

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -393,6 +393,7 @@
 
                                 <ProgressBar Value="{Binding Converter={StaticResource EggDataToEggProgressConverter}}"
                                              Margin="0,5"
+                                             Style="{StaticResource PokemonHPProgressBarStyle}"
                                              Foreground="#399FFF"
                                              IsIndeterminate="False"
                                              HorizontalAlignment="Center" />

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -247,9 +247,13 @@
 
         <Border Margin="12,12,12,0" Background="White" CornerRadius="5,5,0,0">
 
-            <Pivot x:Name="MainUIPanel" SelectionChanged="SelectionChanged">
+            <Pivot x:Name="MainUIPanel" SelectionChanged="SelectionChanged" >
+                
+                <PivotItem x:Name="PokemonsPivot" >
+                    <PivotItem.Header>
+                        <TextBlock>Test</TextBlock>
+                    </PivotItem.Header>
 
-                <PivotItem x:Name="PokemonsPivot">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -308,9 +312,7 @@
                                         <ProgressBar
                                                 Value="{x:Bind Stamina}"
                                                 Maximum="{x:Bind StaminaMax}"
-                                                Style="{StaticResource ExperienceProgressbarStyle}"
-                                                BorderBrush="#6ee8b7"
-                                                BorderThickness="1"
+                                                Style="{StaticResource PokemonHPProgressBarStyle}"
                                                 Margin="0,5"
                                                 Foreground="#6ee8b7"
                                                 IsIndeterminate="False"


### PR DESCRIPTION
### Fixes:

- N/A

### Changes:

- Changes the PlayerProfilePage.xaml experience ProgressBar style to a style similar to the official app. The style is based on [this](https://localtvwtvr.files.wordpress.com/2016/07/160729170850-sam-clark-pokemon-go-profile-exlarge-169.jpg?quality=85&strip=all&w=770&strip=all) image.
- Changes the PokemonInventoryPage.xaml and PokemonDetailPage.xaml HP ProgressBar styles to a style stimilar to the official app. The style is based on [this](http://cdn2.pcadvisor.co.uk/cmsdata/features/3625388/pokemon_go_5c.png) image of the PokemonList and [this](http://i.stack.imgur.com/lfDNW.jpg) image of the PokemonDetail.
- Removed properties which didn't do anything because they weren't bound to in the style used.

### Change details:

- N/A

### Other informations:

- N/A


![wp_ss_20160820_0003 1](https://cloud.githubusercontent.com/assets/11753998/17831661/346d710e-66ef-11e6-95c0-70a126dbcc3a.png)
![wp_ss_20160820_0004 1](https://cloud.githubusercontent.com/assets/11753998/17831663/37f1a70a-66ef-11e6-94d3-356613b6bc62.png)
