### PR TITLE
Fixed 'Something Went Wrong' when running in release mode

### DIFF
--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml
@@ -174,22 +174,13 @@
                 <ListView ItemsSource="{Binding ItemsInventory}"
                           SelectedItem="{Binding SelectedCaptureItem, Mode=TwoWay}"
                           IsItemClickEnabled="True"
-                          Grid.Row="1">
+                          Grid.Row="1" ItemClick="ListView_ItemClick">
 
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                         </Style>
                     </ListView.ItemContainerStyle>
-
-
-                    <interactivity:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="ItemClick">
-                            <core:CallMethodAction MethodName="Begin"
-                                                   TargetObject="{Binding ElementName=HideInventoryMenuStoryboard}" />
-                        </core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
-
 
                     <ListView.ItemTemplate>
                         <DataTemplate>
@@ -276,14 +267,7 @@
                         Grid.Row="2"
                         HorizontalAlignment="Center"
                         Margin="0,8,0,0"
-                        x:Name="CloseInventoryMenuButton">
-
-                    <interactivity:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Tapped">
-                            <core:CallMethodAction MethodName="Begin"
-                                                   TargetObject="{Binding ElementName=HideInventoryMenuStoryboard}" />
-                        </core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
+                        x:Name="CloseInventoryMenuButton" Click="CloseInventoryMenuButton_Click">
 
                     <Image Source="../Assets/Buttons/btn_close_normal_dark.png"
                            Stretch="Uniform"
@@ -519,14 +503,7 @@
                 Margin="16"
                 Height="{ThemeResource UiButtonSize}"
                 HorizontalAlignment="Center"
-                x:Name="InventoryButton">
-
-            <interactivity:Interaction.Behaviors>
-                <core:EventTriggerBehavior EventName="Tapped">
-                    <core:CallMethodAction MethodName="Begin"
-                                           TargetObject="{Binding ElementName=ShowInventoryMenuStoryboard}" />
-                </core:EventTriggerBehavior>
-            </interactivity:Interaction.Behaviors>
+                x:Name="InventoryButton" Click="InventoryButton_Click">
 
             <Image Source="../Assets/Buttons/btn_items_catch.png"
                    Stretch="Uniform"

--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
@@ -343,5 +343,20 @@ namespace PokemonGo_UWP.Views
         }
 
         #endregion
+
+        private void CloseInventoryMenuButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            HideInventoryMenuStoryboard.Begin();
+        }
+
+        private void InventoryButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ShowInventoryMenuStoryboard.Begin();
+        }
+
+        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            HideInventoryMenuStoryboard.Begin();
+        }
     }
 }

--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -505,14 +505,7 @@
                     Height="{ThemeResource UiButtonSize}"
                     RelativePanel.AlignBottomWithPanel="True"
                     RelativePanel.AlignHorizontalCenterWithPanel="True"
-                    Margin="0,0,0,24">
-
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Click">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HidePokeMenuStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                    Margin="0,0,0,24" Click="Button_Click">
 
                 <Image Source="../Assets/Buttons/btn_close_normal.png"
                        Stretch="Uniform"
@@ -636,14 +629,7 @@
                     Height="{ThemeResource UiButtonSize}"
                     RelativePanel.AlignBottomWithPanel="True"
                     RelativePanel.AlignHorizontalCenterWithPanel="True"
-                    Margin="0,0,0,24">
-
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Click">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideLevelUpPanelStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                    Margin="0,0,0,24" Click="Button_Click_1">
 
                 <Image Source="../Assets/Buttons/btn_close_normal_dark.png"
                        Stretch="Uniform"
@@ -727,15 +713,8 @@
                     Style="{ThemeResource ImageButtonStyle}"
                     Height="{ThemeResource UiButtonSize}"
                     HorizontalAlignment="Center"
-                    x:Name="PokeMenuMainButton">
-
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Click">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=ShowPokeMenuStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
-
+                    x:Name="PokeMenuMainButton" Click="PokeMenuMainButton_Click">
+                
                 <Image Source="../Assets/Buttons/btn_action_menu.png"
                        Stretch="Uniform"
                        HorizontalAlignment="Stretch" />

--- a/PokemonGo-UWP/Views/GameMapPage.xaml.cs
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml.cs
@@ -266,5 +266,20 @@ namespace PokemonGo_UWP.Views
             var currentZoomLevel = sender.ZoomLevel;
             sender.ZoomLevel = currentZoomLevel < 17 ? 17 : currentZoomLevel;
         }
+
+        private void PokeMenuMainButton_Click(object sender, RoutedEventArgs e)
+        {
+            ShowPokeMenuStoryboard.Begin();
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            HidePokeMenuStoryboard.Begin();
+        }
+
+        private void Button_Click_1(object sender, RoutedEventArgs e)
+        {
+            HideLevelUpPanelStoryboard.Begin();
+        }
     }
 }

--- a/PokemonGo-UWP/Views/ItemsInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/ItemsInventoryPage.xaml
@@ -105,14 +105,7 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
                     x:Name="CloseDiscardButton"
-                    Margin="24">
-
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Click">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideDiscardStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                    Margin="24" Click="CloseDiscardButton_Click">
 
                 <Image Source="../Assets/Buttons/btn_close_normal_dark.png"
                        Stretch="Uniform"

--- a/PokemonGo-UWP/Views/ItemsInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/ItemsInventoryPage.xaml.cs
@@ -38,5 +38,10 @@ namespace PokemonGo_UWP.Views
         }
 
         #endregion
+
+        private void CloseDiscardButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            HideDiscardStoryboard.Begin();
+        }
     }
 }

--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml
@@ -110,13 +110,8 @@
                             RelativePanel.Above="CustomizeUIStackPanel"
                             Style="{ThemeResource ImageButtonStyle}"
                             Height="{ThemeResource UiButtonSize}"
-                            x:Name="CustomizeUICloseButton">
-                        <interactivity:Interaction.Behaviors>
-                            <core:EventTriggerBehavior EventName="Click">
-                                <core:CallMethodAction MethodName="Begin"
-                                                       TargetObject="{Binding ElementName=HideInventoryStoryboard}" />
-                            </core:EventTriggerBehavior>
-                        </interactivity:Interaction.Behaviors>
+                            x:Name="CustomizeUICloseButton" Click="CustomizeUICloseButton_Click">
+
                         <Image Source="../Assets/Buttons/btn_close_normal_dark.png"
                                Stretch="Uniform"
                                HorizontalAlignment="Stretch" />
@@ -369,14 +364,7 @@
                             Height="{ThemeResource UiButtonSize}"
                             Margin="16"
                             Canvas.ZIndex="9"
-                            x:Name="ShowInventoryButton">
-
-                    <interactivity:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Click">
-                            <core:CallMethodAction MethodName="Begin"
-                                                       TargetObject="{Binding ElementName=ShowInventoryStoryboard}" />
-                        </core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
+                            x:Name="ShowInventoryButton" Click="ShowInventoryButton_Click">
 
                     <Image Source="../Assets/Buttons/btn_menu.png"
                                    HorizontalAlignment="Center"

--- a/PokemonGo-UWP/Views/PlayerProfilePage.xaml.cs
+++ b/PokemonGo-UWP/Views/PlayerProfilePage.xaml.cs
@@ -12,5 +12,14 @@ namespace PokemonGo_UWP.Views
             NavigationCacheMode = NavigationCacheMode.Enabled;
         }
 
+        private void CustomizeUICloseButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            HideInventoryStoryboard.Begin();
+        }
+
+        private void ShowInventoryButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ShowInventoryStoryboard.Begin();
+        }
     }
 }

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -311,7 +311,7 @@
                                     Foreground="White"
                                     Command="{Binding ReplaceEvolvedPokemonCommand}"
                                     Style="{StaticResource RoundedButton}"
-                                    Margin="8">
+                                    Margin="8" Click="Button_Click">
                                 <Button.Background>
                                     <LinearGradientBrush StartPoint="0,4">
                                         <GradientStop Color="#FFA2DB96" />
@@ -319,13 +319,6 @@
                                                       Offset="1" />
                                     </LinearGradientBrush>
                                 </Button.Background>
-
-                                <interactivity:Interaction.Behaviors>
-                                    <core:EventTriggerBehavior EventName="Tapped">
-                                        <core:CallMethodAction MethodName="Begin"
-                                                               TargetObject="{Binding ElementName=HideEvolveMenuStoryboard}" />
-                                    </core:EventTriggerBehavior>
-                                </interactivity:Interaction.Behaviors>
 
                             </Button>
                         </Grid>
@@ -362,7 +355,7 @@
                 <!--Favorite-->
                 <Grid HorizontalAlignment="Right" 
                       Margin="0"
-                      Padding="17.5,4">
+                      Padding="17.5,4" Tapped="Grid_Tapped">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -370,13 +363,6 @@
                     <Grid.RenderTransform>
                         <TranslateTransform Y="150" x:Name="ContextMenuFavoriteTranslateTransform"/>
                     </Grid.RenderTransform>
-                    <interactivity:Interaction.Behaviors>
-                        <core:EventTriggerBehavior EventName="Tapped">
-                            <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideContextMenuStoryboard}" />
-                            <core:InvokeCommandAction Command="{Binding FavoritePokemonCommand}" />
-                        </core:EventTriggerBehavior>
-                    </interactivity:Interaction.Behaviors>
                     <TextBlock Grid.Column="0"
                                Margin="0,0,15,0"
                                x:Uid="FavoriteTextBlock"
@@ -423,13 +409,7 @@
                     Grid.Row="1"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Top"
-                    Margin="17.5,12.5">
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Tapped">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideContextMenuStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                    Margin="17.5,12.5" Click="Button_Click_1">
                 <Image Source="../Assets/Buttons/btn_close.png" />
             </Button>
         </Grid>
@@ -1051,14 +1031,7 @@
                 RelativePanel.AlignRightWithPanel="True"
                 Style="{ThemeResource ImageButtonStyle}"
                 Height="{ThemeResource UiButtonSize}"
-                Margin="16">
-            
-            <interactivity:Interaction.Behaviors>
-                <core:EventTriggerBehavior EventName="Tapped">
-                    <core:CallMethodAction MethodName="Begin"
-                                           TargetObject="{Binding ElementName=ShowContextMenuStoryboard}" />
-                </core:EventTriggerBehavior>
-            </interactivity:Interaction.Behaviors>
+                Margin="16" Click="Button_Click_2">
 
             <Image Source="../Assets/Buttons/btn_menu.png"
                    HorizontalAlignment="Center"

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml.cs
@@ -89,5 +89,25 @@ namespace PokemonGo_UWP.Views
         }
 
         #endregion
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            HideEvolveMenuStoryboard.Begin();
+        }
+
+        private void Button_Click_1(object sender, RoutedEventArgs e)
+        {
+            HideContextMenuStoryboard.Begin();
+        }
+
+        private void Button_Click_2(object sender, RoutedEventArgs e)
+        {
+            ShowContextMenuStoryboard.Begin();
+        }
+
+        private void Grid_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            HideContextMenuStoryboard.Begin();
+        }
     }
 }

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -117,13 +117,7 @@
                       SelectedItem="{Binding CurrentPokemonSortingMode, Mode=TwoWay}"
                       IsItemClickEnabled="True"
                       VerticalAlignment="Bottom"
-                      Margin="0,0,0,77.5">
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="ItemClick">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideSortMenuStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                      Margin="0,0,0,77.5" ItemClick="ListView_ItemClick">
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="Margin" Value="0" />
@@ -153,14 +147,7 @@
                     Style="{StaticResource ButtonCircleInverse}"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
-                    Margin="0,0,0,17.5">
-
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Click">
-                        <core:CallMethodAction MethodName="Begin"
-                                               TargetObject="{Binding ElementName=HideSortMenuStoryboard}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
+                    Margin="0,0,0,17.5" Click="CloseSortMenuButton_Click">
 
                 <Image Source="../Assets/Buttons/btn_close_dark.png" />
             </Button>
@@ -323,13 +310,7 @@
                         <Button x:Name="SortingButton"
                                 Grid.Row="1"
                                 Style="{StaticResource ButtonCircleBigInverse}"
-                                Margin="16">
-                            <interactivity:Interaction.Behaviors>
-                                <core:EventTriggerBehavior EventName="Click">
-                                    <core:CallMethodAction MethodName="Begin"
-                                                           TargetObject="{Binding ElementName=ShowSortMenuStoryboard}" />
-                                </core:EventTriggerBehavior>
-                            </interactivity:Interaction.Behaviors>
+                                Margin="16" Click="SortingButton_Click">
                             <Image
                                 Source="{Binding CurrentPokemonSortingMode, Converter={StaticResource PokemonSortingModesToIconConverter}}" />
                         </Button>

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml.cs
@@ -101,5 +101,19 @@ namespace PokemonGo_UWP.Views
 			}
 		}
 
-	}
+        private void CloseSortMenuButton_Click(object sender, RoutedEventArgs e)
+        {
+            HideSortMenuStoryboard.Begin();
+        }
+
+        private void SortingButton_Click(object sender, RoutedEventArgs e)
+        {
+            ShowSortMenuStoryboard.Begin();
+        }
+
+        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            HideSortMenuStoryboard.Begin();
+        }
+    }
 }


### PR DESCRIPTION
### Fixes:

- When compiled in release mode, pressing buttons or tapping in listview items it results in a 'Something went wrong' message.

### Changes:

- Removed <interactivity:Interaction.Behaviors> from items and replaced with normal XAML handlers

### Change details:
When tapping on buttons or ListView items before, the messagebox would appear due to the interaction stuff being unable to find Storyboard.Begin. This change simply calls it in the CS code instead of the xaml.

### Other informations:
I realise that this isn't strictly MvvM but it fixes the bug and the app actually runs a bit better without it. I've tested this on both my phone (Lumia 950) and PC without issues. I'm fairly sure i've replaced all the ones which called Storyboard.Begin but i may have missed a few. If it still occurs it'll be in places which are hard to test (such as egg hatching).
