### PR TITLE
PokemonInventory: Show both pivot Headers

### DIFF
--- a/PokemonGo-UWP/App.xaml
+++ b/PokemonGo-UWP/App.xaml
@@ -66,7 +66,7 @@
             <utils:InverseVisibleWhenTypeIsNotNoneConverter x:Key="InverseVisibleWhenTypeIsNotNoneConverter"/>
             <utils:PokemonDataToCapturedGepositionConverter x:Key="PokemonDataToCapturedGepositionConverter"/>
             <utils:AchievementDescriptionTranslationConverter x:Key="AchievementDescriptionTranslationConverter"/>
-            
+            <utils:PokemonPivotHeaderToVisibleConverter x:Key="PokemonPivotHeaderToVisibleConverter" />
 
             <converters:ValueWhenConverter x:Key="EnabledWhenHasElementsConverter">
                 <converters:ValueWhenConverter.When>

--- a/PokemonGo-UWP/Styles/Custom.xaml
+++ b/PokemonGo-UWP/Styles/Custom.xaml
@@ -1352,7 +1352,7 @@
         <Setter Property="Foreground" Value="#FF888F93" />
     </Style>
 
-    <Style TargetType="Pivot">
+    <Style TargetType="Pivot" x:Key="PokemonInventoryPivotStyle">
         <Setter Property="Margin" Value="0"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Background" Value="Transparent"/>
@@ -1514,14 +1514,14 @@
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="0"/>
+                                            <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="*"/>
                                         </Grid.RowDefinitions>
                                         <Grid.RenderTransform>
                                             <CompositeTransform x:Name="PivotLayoutElementTranslateTransform"/>
                                         </Grid.RenderTransform>
                                         <ContentPresenter x:Name="LeftHeaderPresenter" ContentTemplate="{TemplateBinding LeftHeaderTemplate}" Content="{TemplateBinding LeftHeader}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
-                                        <ContentControl x:Name="HeaderClipper" Grid.Column="1" HorizontalContentAlignment="Stretch" UseSystemFocusVisuals="True">
+                                        <ContentControl x:Name="HeaderClipper" Grid.Column="1" HorizontalContentAlignment="Center" UseSystemFocusVisuals="True">
                                             <ContentControl.Clip>
                                                 <RectangleGeometry x:Name="HeaderClipperGeometry"/>
                                             </ContentControl.Clip>
@@ -1557,7 +1557,11 @@
             </Setter.Value>
         </Setter>
     </Style>
-    
+
+    <Style TargetType="PivotHeaderItem">
+        <Setter Property="Height" Value="Auto" />
+    </Style>
+
     <Style x:Key="SettingsCheckbox" TargetType="CheckBox">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="Transparent" />

--- a/PokemonGo-UWP/Styles/Custom.xaml
+++ b/PokemonGo-UWP/Styles/Custom.xaml
@@ -1392,22 +1392,6 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="Orientation">
-                                <VisualState x:Name="Portrait">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Margin" Storyboard.TargetName="TitleContentControl">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPortraitThemePadding}"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Landscape">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Margin" Storyboard.TargetName="TitleContentControl">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotLandscapeThemePadding}"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
                             <VisualStateGroup x:Name="NavigationButtonsVisibility">
                                 <VisualState x:Name="NavigationButtonsHidden"/>
                                 <VisualState x:Name="NavigationButtonsVisible">

--- a/PokemonGo-UWP/Utils/Game/Converters.cs
+++ b/PokemonGo-UWP/Utils/Game/Converters.cs
@@ -1274,4 +1274,23 @@ namespace PokemonGo_UWP.Utils
 
         #endregion
     }
+
+    public class PokemonPivotHeaderToVisibleConverter : IValueConverter
+    {
+        #region IValueConverter PokemonPivotHeaderToVisible
+
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var selectedPivotIndex = System.Convert.ToUInt64(value);
+            var thisPivotIndex = System.Convert.ToUInt64(parameter);
+            return (selectedPivotIndex == thisPivotIndex) ? "0.0" : "1.0";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return value;
+        }
+
+        #endregion
+    }
 }

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -245,179 +245,178 @@
         </Grid>
         <!-- Da rifare -->
 
-        <Border Margin="12,12,12,0" Background="White" CornerRadius="5,5,0,0">
+         <Border Margin="12,0,12,0" Background="White" CornerRadius="5,5,0,0">
+           <Pivot x:Name="MainUIPanel"
+                  SelectionChanged="SelectionChanged"
+                  Style="{StaticResource PokemonInventoryPivotStyle}">
+              <PivotItem x:Name="PokemonsPivot">
+                  <PivotItem.Header>
+                     <StackPanel Orientation="Vertical">
+                        <TextBlock Text="POKÉMON"
+                                   Style="{StaticResource TextPageTitleDark}"
+                                   Margin="15,15,15,3"
+                                   Foreground="#FF44696C" FontSize="18"
+                                   Width="150" />
+                        <TextBlock Style="{StaticResource TextSubTitle}"
+                                   HorizontalAlignment="Center"
+                                   Foreground="#FF44696C">
+                           <Run Text="{x:Bind ViewModel.PokemonInventory.Count}" />
+                           <Run Text=" / " />
+                           <Run Text="250" />
+                        </TextBlock>
+                        <Rectangle Fill="#FF44696C"
+                                   Height="2"
+                                   Margin="20,3,20,15"
+                                   RadiusX="2"
+                                   RadiusY="2"
+                                   Opacity ="{Binding SelectedIndex, ElementName=MainUIPanel, ConverterParameter=1,
+                                             Converter={StaticResource PokemonPivotHeaderToVisibleConverter}}" />
+                     </StackPanel>
+                  </PivotItem.Header>
+                 <Grid>
+                    <Grid.RowDefinitions>
+                       <RowDefinition Height="Auto" />
+                       <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <GridView x:Name="PokemonInventoryGridView"
+                              ItemsSource="{x:Bind ViewModel.PokemonInventory, Mode=OneWay}"
+                              Grid.Row="1"
+                              SelectionMode="None"
+                              Padding="0,0,0,57.5"
+                              ShowsScrollingPlaceholders="True"
+                              SizeChanged="GridViewPokemonSizeChanged">
 
-            <Pivot x:Name="MainUIPanel" SelectionChanged="SelectionChanged">
+                       <GridView.ItemTemplate>
+                          <DataTemplate x:DataType="entities:PokemonDataWrapper">
+                             <StackPanel HorizontalAlignment="Center"
+                                         VerticalAlignment="Top"
+                                         Margin="0,0,0,10">
 
-                <PivotItem x:Name="PokemonsPivot">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0">
-                            <TextBlock x:Name="PokemonsPivotHeader"
-                                       x:Uid="PokemonText"
-                                       Text="POKEMON"
-                                       Style="{StaticResource TextPageTitleDark}" />
-                            <Border Background="#000" Width="150" Height="1" />
-                            <TextBlock Style="{StaticResource TextSubTitle}"
-                                       HorizontalAlignment="Center"
-                                       Margin="0,8">
-                                <Run Text="{x:Bind ViewModel.PokemonInventory.Count}" />
-                                <Run Text=" / " />
-                                <Run Text="250" />
-                            </TextBlock>
-                        </StackPanel>
-                        <GridView x:Name="PokemonInventoryGridView"
-                                      ItemsSource="{x:Bind ViewModel.PokemonInventory, Mode=OneWay}"
-                                      Grid.Row="1"
-                                      SelectionMode="None"
-                                      Padding="0,0,0,57.5"
-                                      ShowsScrollingPlaceholders="True"                                  
-                                      SizeChanged="GridViewPokemonSizeChanged">
+                                <interactivity:Interaction.Behaviors>
+                                   <core:EventTriggerBehavior EventName="Tapped">
+                                      <core:InvokeCommandAction Command="{x:Bind GotoPokemonDetailsCommand}" />
+                                   </core:EventTriggerBehavior>
+                                </interactivity:Interaction.Behaviors>
 
-                            <GridView.ItemTemplate>
-                                <DataTemplate x:DataType="entities:PokemonDataWrapper">
-                                    <StackPanel HorizontalAlignment="Center"
-                                                    VerticalAlignment="Top"
-                                                    Margin="0,0,0,10">
+                                <TextBlock Style="{StaticResource TextGridViewTop}">
+                                   <Run x:Uid="CpTextBlock" Text="CP" />
+                                   <Run FontSize="15" Text="{x:Bind Cp}"/>
+                                </TextBlock>
+                                <Image Source="{x:Bind PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
+                                       Width="48"
+                                       Height="48"
+                                       Margin="5"
+                                       x:Phase="2" />
+                                <TextBlock Text="{x:Bind PokemonId, Converter={StaticResource PokemonIdToPokemonNameConverter}}"
+                                           Style="{StaticResource TextPokemonName}"
+                                           x:Phase="0" />
+                                <ProgressBar Value="{x:Bind Stamina}"
+                                             Maximum="{x:Bind StaminaMax}"
+                                             Margin="0,5"
+                                             Foreground="#6ee8b7"
+                                             IsIndeterminate="False"
+                                             HorizontalAlignment="Center"
+                                             x:Phase="1" />
+                             </StackPanel>
+                          </DataTemplate>
+                       </GridView.ItemTemplate>
+                    </GridView>
+                    <Button x:Name="SortingButton"
+                            Grid.Row="1"
+                            Style="{StaticResource ButtonCircleBigInverse}"
+                            Margin="16">
+                       <interactivity:Interaction.Behaviors>
+                          <core:EventTriggerBehavior EventName="Click">
+                             <core:CallMethodAction MethodName="Begin"
+                                                    TargetObject="{Binding ElementName=ShowSortMenuStoryboard}" />
+                          </core:EventTriggerBehavior>
+                       </interactivity:Interaction.Behaviors>
+                       <Image Source="{Binding CurrentPokemonSortingMode, Converter={StaticResource PokemonSortingModesToIconConverter}}" />
+                    </Button>
+                 </Grid>
+              </PivotItem>
 
-                                        <interactivity:Interaction.Behaviors>
-                                            <core:EventTriggerBehavior EventName="Tapped">
-                                                <core:InvokeCommandAction
-                                                        Command="{x:Bind GotoPokemonDetailsCommand}" />
-                                            </core:EventTriggerBehavior>
-                                        </interactivity:Interaction.Behaviors>
+              <PivotItem x:Name="EggsPivot">
+                  <PivotItem.Header>
+                     <StackPanel Orientation="Vertical">
+                        <TextBlock Text="EGGS"
+                                   Style="{StaticResource TextPageTitleDark}"
+                                   Margin="15,15,15,3"
+                                   Foreground="#FF44696C" FontSize="18"
+                                   Width="150" />
+                        <TextBlock Style="{StaticResource TextSubTitle}"
+                                   HorizontalAlignment="Center"
+                                   Foreground="#FF44696C">
+                           <Run Text="{x:Bind ViewModel.EggsInventory.Count}" />
+                           <Run Text=" / " />
+                           <Run Text="9" />
+                        </TextBlock>
+                        <Rectangle Fill="#FF44696C"
+                                   Height="2"
+                                   Margin="20,3,20,15"
+                                   RadiusX="2"
+                                   RadiusY="2"
+                                   Opacity ="{Binding SelectedIndex, ElementName=MainUIPanel, ConverterParameter=0,
+                                             Converter={StaticResource PokemonPivotHeaderToVisibleConverter}}" />
+                     </StackPanel>
+                  </PivotItem.Header>
+                 <Grid>
+                    <Grid.RowDefinitions>
+                       <RowDefinition Height="Auto" />
+                       <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <GridView x:Name="EggsInventoryGridView"
+                              ItemsSource="{x:Bind ViewModel.EggsInventory}"
+                              SelectionMode="None"
+                              Grid.Row="1"
+                              Padding="0,0,0,57.5"
+                              SizeChanged="GridViewEggsSizeChanged">
 
-                                        <TextBlock Style="{StaticResource TextGridViewTop}">
-                                                <Run x:Uid="CpTextBlock"
-                                                     Text="CP" />
-                                                <Run FontSize="15" Text="{x:Bind Cp}"/>
-                                        </TextBlock>
-                                        <Image
-                                                Source="{x:Bind PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
-                                                Width="48"
-                                                Height="48"
-                                                Margin="5"
-                                                x:Phase="2" />
-                                        <TextBlock
-                                                Text="{x:Bind PokemonId, Converter={StaticResource PokemonIdToPokemonNameConverter}}"
-                                                Style="{StaticResource TextPokemonName}"
-                                                x:Phase="0" />
-                                        <ProgressBar
-                                                Value="{x:Bind Stamina}"
-                                                Maximum="{x:Bind StaminaMax}"
-                                                Style="{StaticResource ExperienceProgressbarStyle}"
-                                                BorderBrush="#6ee8b7"
-                                                BorderThickness="1"
-                                                Margin="0,5"
-                                                Foreground="#6ee8b7"
-                                                IsIndeterminate="False"
-                                                HorizontalAlignment="Center"
-                                                x:Phase="1" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </GridView.ItemTemplate>
-                        </GridView>
-                        <Button x:Name="SortingButton"
-                                Grid.Row="1"
-                                Style="{StaticResource ButtonCircleBigInverse}"
-                                Margin="16">
-                            <interactivity:Interaction.Behaviors>
-                                <core:EventTriggerBehavior EventName="Click">
-                                    <core:CallMethodAction MethodName="Begin"
-                                                           TargetObject="{Binding ElementName=ShowSortMenuStoryboard}" />
-                                </core:EventTriggerBehavior>
-                            </interactivity:Interaction.Behaviors>
-                            <Image
-                                Source="{Binding CurrentPokemonSortingMode, Converter={StaticResource PokemonSortingModesToIconConverter}}" />
-                        </Button>
-                    </Grid>
-                </PivotItem>
+                       <GridView.ItemTemplate>
+                          <DataTemplate x:DataType="entities:PokemonDataWrapper">
+                             <StackPanel HorizontalAlignment="Center"
+                                         VerticalAlignment="Top"
+                                         Margin="0,0,0,10">
 
-                <PivotItem x:Name="EggsPivot">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0">
-                            <TextBlock x:Name="EggsPivotHeader"
-                                       x:Uid="EggsTextBlock"
-                                       Text="EGGS"
-                                       Style="{StaticResource TextPageTitleDark}" />
-                            <Border Background="#000" Width="150" Height="1" />
-                            <TextBlock Style="{StaticResource TextSubTitle}"
-                                       HorizontalAlignment="Center"
-                                       Margin="0,8">
-                                <Run Text="{x:Bind ViewModel.EggsInventory.Count}" />
-                                <Run Text=" / " />
-                                <Run Text="9" />
-                            </TextBlock>
-                        </StackPanel>
-                        <GridView x:Name="EggsInventoryGridView"
-                                      ItemsSource="{x:Bind ViewModel.EggsInventory}"
-                                      SelectionMode="None"
-                                      Grid.Row="1"
-                                      Padding="0,0,0,57.5"
-                                      SizeChanged="GridViewEggsSizeChanged">
+                                <interactivity:Interaction.Behaviors>
+                                   <core:EventTriggerBehavior EventName="Tapped">
+                                      <core:InvokeCommandAction Command="{x:Bind GotoEggDetailsCommand}" />
+                                   </core:EventTriggerBehavior>
+                                </interactivity:Interaction.Behaviors>
 
-                            <GridView.ItemTemplate>
-                                <DataTemplate x:DataType="entities:PokemonDataWrapper">
-                                    <StackPanel HorizontalAlignment="Center"
-                                                    VerticalAlignment="Top"
-                                                    Margin="0,0,0,10">
+                                <Image Source="{x:Bind Converter={StaticResource EggDataToEggIconConverter}}"
+                                       Width="48"
+                                       Height="48"
+                                       Margin="5"
+                                       x:Phase="2" />
 
-                                        <interactivity:Interaction.Behaviors>
-                                            <core:EventTriggerBehavior EventName="Tapped">
-                                                <core:InvokeCommandAction Command="{x:Bind GotoEggDetailsCommand}" />
-                                            </core:EventTriggerBehavior>
-                                        </interactivity:Interaction.Behaviors>
+                                <ProgressBar Value="{Binding Converter={StaticResource EggDataToEggProgressConverter}}"
+                                             Margin="0,5"
+                                             Foreground="#399FFF"
+                                             IsIndeterminate="False"
+                                             HorizontalAlignment="Center" />
 
-                                        <Image
-                                                Source="{x:Bind Converter={StaticResource EggDataToEggIconConverter}}"
-                                                Width="48"
-                                                Height="48"
-                                                Margin="5"
-                                                x:Phase="2" />
-
-                                        <ProgressBar
-                                                Value="{Binding Converter={StaticResource EggDataToEggProgressConverter}}"
-                                                Margin="0,5"
-                                                Foreground="#399FFF"
-                                                IsIndeterminate="False"
-                                                HorizontalAlignment="Center"
-                                                 />
-
-                                        <TextBlock Style="{StaticResource TextGridViewTop}">
-                                                <Run
-                                                    Text="{Binding EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.#\}}"
-                                                     />
-                                                <Run Text="/" />
-                                                <Run FontWeight="Bold"
-                                                     Text="{Binding EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0\}}"
-                                                     />
-                                                <Run FontWeight="Bold"
-                                                     Text="km" />
-                                        </TextBlock>
-
-                                    </StackPanel>
-                                </DataTemplate>
-                            </GridView.ItemTemplate>
-                        </GridView>
-                        
-                        <Button x:Name="IncubatorButton" Grid.Row="1"
-                                Style="{StaticResource ButtonCircleBigInverse}"
-                                Tapped="ToggleIncubatorModel"
-                                Margin="16">
-                            <Image Source="../Assets/Buttons/btn_incubator_dark.png" />
-                        </Button>
-                        
-                    </Grid>
-                </PivotItem>
-
-            </Pivot>
+                                <TextBlock Style="{StaticResource TextGridViewTop}">
+                                   <Run Text="{Binding EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.#\}}" />
+                                   <Run Text="/" />
+                                   <Run FontWeight="Bold"
+                                        Text="{Binding EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0\}}" />
+                                   <Run FontWeight="Bold"
+                                        Text="km" />
+                                </TextBlock>
+                             </StackPanel>
+                          </DataTemplate>
+                       </GridView.ItemTemplate>
+                    </GridView>
+                    <Button x:Name="IncubatorButton" Grid.Row="1"
+                            Style="{StaticResource ButtonCircleBigInverse}"
+                            Tapped="ToggleIncubatorModel"
+                            Margin="16">
+                       <Image Source="../Assets/Buttons/btn_incubator_dark.png" />
+                    </Button>
+                 </Grid>
+              </PivotItem>
+           </Pivot>
         </Border>
 
         <Button Command="{Binding ReturnToGameScreen}"

--- a/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonInventoryPage.xaml
@@ -254,9 +254,8 @@
                      <StackPanel Orientation="Vertical">
                         <TextBlock Text="POKÉMON"
                                    Style="{StaticResource TextPageTitleDark}"
-                                   Margin="15,15,15,3"
-                                   Foreground="#FF44696C" FontSize="18"
-                                   Width="150" />
+                                   Margin="10,10,10,3"
+                                   Foreground="#FF44696C" FontSize="18" />
                         <TextBlock Style="{StaticResource TextSubTitle}"
                                    HorizontalAlignment="Center"
                                    Foreground="#FF44696C">
@@ -266,9 +265,10 @@
                         </TextBlock>
                         <Rectangle Fill="#FF44696C"
                                    Height="2"
-                                   Margin="20,3,20,15"
+                                   Margin="10,3,10,10"
                                    RadiusX="2"
                                    RadiusY="2"
+                                   Width="100"
                                    Opacity ="{Binding SelectedIndex, ElementName=MainUIPanel, ConverterParameter=1,
                                              Converter={StaticResource PokemonPivotHeaderToVisibleConverter}}" />
                      </StackPanel>
@@ -341,9 +341,8 @@
                      <StackPanel Orientation="Vertical">
                         <TextBlock Text="EGGS"
                                    Style="{StaticResource TextPageTitleDark}"
-                                   Margin="15,15,15,3"
-                                   Foreground="#FF44696C" FontSize="18"
-                                   Width="150" />
+                                   Margin="10,10,10,3"
+                                   Foreground="#FF44696C" FontSize="18" />
                         <TextBlock Style="{StaticResource TextSubTitle}"
                                    HorizontalAlignment="Center"
                                    Foreground="#FF44696C">
@@ -353,9 +352,10 @@
                         </TextBlock>
                         <Rectangle Fill="#FF44696C"
                                    Height="2"
-                                   Margin="20,3,20,15"
+                                   Margin="15,3,15,15"
                                    RadiusX="2"
                                    RadiusY="2"
+                                   Width="100"
                                    Opacity ="{Binding SelectedIndex, ElementName=MainUIPanel, ConverterParameter=0,
                                              Converter={StaticResource PokemonPivotHeaderToVisibleConverter}}" />
                      </StackPanel>


### PR DESCRIPTION
### Changes:

- Show both pivot headers in pokémon inventory.
- Chaged pivo header style to better aproximate iOS app.

### Change details:
Pivot Headers were hardcoded into grid and the default headers were hidden in style.
Used styled default headers for the pivot instead.
Show both Pokemon and Egg headers.
Added new converter for Pivot Header Bar visibility.

![2016-08-20 3](https://cloud.githubusercontent.com/assets/5551150/17833330/a00e08da-671a-11e6-9159-f0d93b9b41d3.png)
![2016-08-20 2](https://cloud.githubusercontent.com/assets/5551150/17833331/a0239f92-671a-11e6-9264-8f1c4bb5cb55.png)