### PR TITLE
Compassless crash

### DIFF
--- a/PokemonGo-UWP/Views/SettingsPage.xaml
+++ b/PokemonGo-UWP/Views/SettingsPage.xaml
@@ -84,7 +84,7 @@
 									SelectedIndex="{Binding MapAutomaticOrientationMode_Index, Mode=TwoWay}" >
 					<ComboBoxItem Content="None"/>
 					<ComboBoxItem Content="GPS"/>
-					<ComboBoxItem Content="Compass"/>
+					<ComboBoxItem x:Name="CompassBoxItem" Content="Compass"/>
 				</ComboBox>
 
                 <TextBlock Grid.Row="2"

--- a/PokemonGo-UWP/Views/SettingsPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SettingsPage.xaml.cs
@@ -7,6 +7,9 @@ namespace PokemonGo_UWP.Views
         public SettingsPage()
         {
             InitializeComponent();
+            if (Windows.Devices.Sensors.Compass.GetDefault() == null){
+                CompassBoxItem.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+            }
         }
     }
 }


### PR DESCRIPTION
### Fixes:

- Phones with compasses can no longer turn on compass rotate mode

### Changes:

- ComboBoxItem doesn't showup

### Other informations:

Currently, on phones with no compass they crash if you select compass for auto-rotate