### PR TITLE
replace order to catchable the pokemon under the pokestop #1067

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -258,6 +258,23 @@
                    Width="48"
                    x:Name="PlayerImage" />
 
+            <maps:MapItemsControl ItemsSource="{Binding NearbyPokestops}">
+                <maps:MapItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="entities:FortDataWrapper">
+                        <Button Style="{ThemeResource ImageButtonStyle}"
+                                Command="{x:Bind TrySearchPokestop}">
+                            <Image
+                                Source="{Binding FortDataStatus, Converter={StaticResource PokestopToIconConverter}}"
+                                maps:MapControl.Location="{Binding Geoposition}"
+                                maps:MapControl.NormalizedAnchorPoint="{Binding Anchor}"
+                                Stretch="Uniform"
+                                Height="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=2}"
+                                Width="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=2}" />
+                        </Button>
+                    </DataTemplate>
+                </maps:MapItemsControl.ItemTemplate>
+            </maps:MapItemsControl>
+
             <maps:MapItemsControl ItemsSource="{Binding CatchablePokemons}">
                 <maps:MapItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="entities:MapPokemonWrapper">
@@ -289,23 +306,6 @@
                                 Canvas.ZIndex="4"
                                 Height="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=1}"
                                 Width="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=1}" />
-                        </Button>
-                    </DataTemplate>
-                </maps:MapItemsControl.ItemTemplate>
-            </maps:MapItemsControl>
-
-            <maps:MapItemsControl ItemsSource="{Binding NearbyPokestops}">
-                <maps:MapItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="entities:FortDataWrapper">
-                        <Button Style="{ThemeResource ImageButtonStyle}"
-                                Command="{x:Bind TrySearchPokestop}">
-                            <Image
-                                Source="{Binding FortDataStatus, Converter={StaticResource PokestopToIconConverter}}"
-                                maps:MapControl.Location="{Binding Geoposition}"
-                                maps:MapControl.NormalizedAnchorPoint="{Binding Anchor}"
-                                Stretch="Uniform"
-                                Height="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=2}"
-                                Width="{Binding ZoomLevel, ElementName=GameMapControl, Converter={StaticResource MapZoomLevelToIconSizeConverter}, ConverterParameter=2}" />
                         </Button>
                     </DataTemplate>
                 </maps:MapItemsControl.ItemTemplate>


### PR DESCRIPTION
### Fixes:

- Fix the #1067 issue: pokémon under the pokestop cannot be catched

### Changes:

- reordered the element of the catchablepokemon, pokestop and luredpokemon item in gamemapmage.xml

### Change details:
 - The original idea is came from SlowSlash.
 - I just made it for github project.

