### PR TITLE
Changed the way we hide the StatusBar and added overlay support

### DIFF
--- a/PokemonGo-UWP/App.xaml.cs
+++ b/PokemonGo-UWP/App.xaml.cs
@@ -199,6 +199,7 @@ namespace PokemonGo_UWP
 
             // Enter into full screen mode
             ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
+            ApplicationView.GetForCurrentView().SetDesiredBoundsMode(ApplicationViewBoundsMode.UseCoreWindow);
             ApplicationView.GetForCurrentView().FullScreenSystemOverlayMode = FullScreenSystemOverlayMode.Standard;            
 
             // Forces the display to stay on while we play

--- a/PokemonGo-UWP/App.xaml.cs
+++ b/PokemonGo-UWP/App.xaml.cs
@@ -191,7 +191,7 @@ namespace PokemonGo_UWP
             Logger.SetLogger(new ConsoleLogger(LogLevel.Info));
 #endif            
             // If we have a phone contract, hide the status bar
-            if (ApiInformation.IsApiContractPresent("Windows.Phone.PhoneContract", 1, 0))
+            if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
             {
                 var statusBar = StatusBar.GetForCurrentView();
                 await statusBar.HideAsync();


### PR DESCRIPTION
### Fixes:
- We check if we have a phone to hide the status bar. Now we check if a StatusBar is available.

### Changes:
- Added overlay support so now the app wont resize when the user summons the Navigation bar(back button, windows button, search button)

### Change details:
Picture of how the app responds when we summon the Navigation bar: [Picture](http://prnt.sc/c8weaa)

### Other information:
-Tapping anywhere on the screen will dismiss the Navigation bar.
-The overlay support will help to display the status bar too in the near future like the official app.
