### PR TITLE
Added transfer context menu icons

### DIFF
--- a/PokemonGo-UWP/PokemonGo-UWP.csproj
+++ b/PokemonGo-UWP/PokemonGo-UWP.csproj
@@ -214,9 +214,11 @@
     <Content Include="Assets\Icons\Footprint_Mid.png" />
     <Content Include="Assets\Icons\Footprint_Near.png" />
     <Content Include="Assets\Icons\FrontPortraitRing.png" />
+    <Content Include="Assets\Icons\ic_candy_light.png" />
     <Content Include="Assets\Icons\ic_combat.png" />
     <Content Include="Assets\Icons\ic_date.png" />
     <Content Include="Assets\Icons\ic_fav.png" />
+    <Content Include="Assets\Icons\ic_fav_light.png" />
     <Content Include="Assets\Icons\ic_health.png" />
     <Content Include="Assets\Icons\ic_name.png" />
     <Content Include="Assets\Icons\ic_number.png" />

--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -361,7 +361,7 @@
 
                 <!--Favorite-->
                 <Grid HorizontalAlignment="Right" 
-                      Margin="0"
+                      Margin="0,15,0,0"
                       Padding="17.5,4">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -382,10 +382,10 @@
                                Text="FAVORITE"
                                Style="{StaticResource TextSortTitle}" />
                     <Image Grid.Column="1"
-                           Height="15"
-                           Width="15"
+                           Height="25"
+                           Width="25"
                            Margin="12,5"
-                           Source="../Assets/Buttons/btn_close.png" />
+                           Source="../Assets/Icons/ic_fav_light.png" />
                 </Grid>
 
                 <!--Transfer-->
@@ -410,10 +410,10 @@
                                Text="TRANSFER"
                                Style="{StaticResource TextSortTitle}" />
                     <Image Grid.Column="1"
-                           Height="15"
-                           Width="15"
+                           Height="25"
+                           Width="25"
                            Margin="12,5"
-                           Source="../Assets/Buttons/btn_close.png" />
+                           Source="../Assets/Icons/ic_candy_light.png" />
                 </Grid>
             </StackPanel>
 


### PR DESCRIPTION
### Fixes:

Does not contain any fixes.

### Changes:

Added icons to pokemon detail page context menu.

### Other informations:

![wp_ss_20160822_0001](https://cloud.githubusercontent.com/assets/11668257/17873775/eb2bbd10-689d-11e6-8228-345402d4b338.png)