### PR TITLE
Fixed missing translation for Pokémon type if it had only 1

### DIFF
--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -664,7 +664,7 @@
                                                    Margin="32,0"
                                                    FontSize="19"
                                                    Grid.Row="0"
-                                                   Text="{Binding PokemonExtraData.Type}"
+                                                   Text="{Binding PokemonExtraData.Type, Converter={StaticResource PokemonTypeTranslationConverter}}"
                                                    Visibility="{Binding PokemonExtraData.Type2, Converter={StaticResource InverseVisibleWhenTypeIsNotNoneConverter}}"
                                                    Foreground="#577074" />
 


### PR DESCRIPTION
### Fixes:

- If Pokémon had only 1 Type instead of 2 (water instead of grass/water), the translation converter wasn't applied