### PR TITLE
Added Pokemon Go like Message Dialog

### DIFF
--- a/PokemonGo-UWP/Controls/MessageDialog.cs
+++ b/PokemonGo-UWP/Controls/MessageDialog.cs
@@ -1,0 +1,127 @@
+﻿
+using System;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace PokemonGo_UWP.Controls {
+    public class MessageDialog {
+        /// <summary>
+        /// Enum for Buttons, which will be shown.
+        /// </summary>
+        public enum MessageDialogType {
+            OkOnly,
+            YesNo
+        }
+
+        /// <summary>
+        /// Enum for dialog results.
+        /// </summary>
+        public enum MessageDialogResult {
+            Ok,
+            Yes,
+            No
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="type">Type of Buttons, which will be shown</param>
+        /// <param name="message">Message, which will be shown</param>
+        public MessageDialog(MessageDialogType type, string message) {
+            MessageDialogChild dialog = new MessageDialogChild(type, message);
+            dialog.YesButtonTapped += Dialog_YesButtonTapped;
+            dialog.NoButtonTapped += Dialog_NoButtonTapped;
+            dialog.OkButtonTapped += Dialog_OkButtonTapped;
+            Dialog.Content = dialog;
+        }
+
+        #region Vars
+
+        /// <summary>
+        /// Content Dialog, which handles the User Control MessageDialogChild.
+        /// </summary>
+        private ContentDialog Dialog { get; set; } = new ContentDialog();
+
+        public MessageDialogResult Result { get; set; }
+
+        #endregion
+
+        #region Logic
+
+        /// <summary>
+        /// Shows the MessageDialog asynchornously.
+        /// </summary>
+        /// <returns>Result, which button was pressed</returns>
+        public async Task<MessageDialogResult> ShowAsync() {
+            CreateDialogStyle();
+            await Dialog.ShowAsync();
+            return Result;
+        }
+
+        /// <summary>
+        /// Hides the dialog.
+        /// </summary>
+        private void Hide() {
+            Dialog.Hide();
+        }
+
+        /// <summary>
+        /// Create the Style for the Content dialog
+        /// </summary>
+        private void CreateDialogStyle() {
+            Dialog.Padding = new Thickness(0);
+            Dialog.Margin = new Thickness(0);
+            Dialog.BorderThickness = new Thickness(0);
+            SolidColorBrush brush = new SolidColorBrush(Colors.Transparent);
+            brush.Opacity = 0.5;
+
+            Dialog.Background = brush;
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        ///     Event fired, if user pressed YES
+        /// </summary>
+        public event EventHandler YesButtonTapped;
+
+        /// <summary>
+        ///     Event fired, if user pressed NO
+        /// </summary>
+        public event EventHandler NoButtonTapped;
+
+        /// <summary>
+        ///     Event fired, if user pressed OK
+        /// </summary>
+        public event EventHandler OkButtonTapped;
+
+        #endregion
+
+        #region Event Handlers
+
+        private void Dialog_YesButtonTapped(object sender, EventArgs e) {
+            YesButtonTapped?.Invoke(this, null);
+            Result = MessageDialogResult.Yes;
+            this.Hide();
+        }
+
+        private void Dialog_NoButtonTapped(object sender, EventArgs e) {
+            NoButtonTapped?.Invoke(this, null);
+            Result = MessageDialogResult.No;
+            this.Hide();
+        }
+
+        private void Dialog_OkButtonTapped(object sender, EventArgs e) {
+            OkButtonTapped?.Invoke(this, null);
+            Result = MessageDialogResult.Ok;
+            this.Hide();
+        }
+
+        #endregion
+    }
+}

--- a/PokemonGo-UWP/Controls/Utils/MessageDialogChild.xaml
+++ b/PokemonGo-UWP/Controls/Utils/MessageDialogChild.xaml
@@ -1,0 +1,64 @@
+﻿<UserControl
+    x:Class="PokemonGo_UWP.Controls.MessageDialogChild"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:PokemonGo_UWP.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    HorizontalAlignment="Center"
+    VerticalAlignment="Center">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Button" BasedOn="{StaticResource ButtonSubmit}">
+                <Setter Property="MinWidth" Value="200"/>
+                <Setter Property="Margin" Value="0,0,0,15"/>
+                <Setter Property="FontSize" Value="18"/>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <RelativePanel HorizontalAlignment="Center"
+                   VerticalAlignment="Center">
+
+        <RelativePanel RelativePanel.AlignLeftWithPanel="True"
+                       RelativePanel.AlignRightWithPanel="True"
+                       RelativePanel.AlignVerticalCenterWithPanel="True"
+                       Background="White"
+                       CornerRadius="5"
+                       BorderThickness="1"
+                       BorderBrush="#35908f"
+                       Margin="20">
+            <TextBlock x:Name="MessageTextBlock"
+                       RelativePanel.AlignTopWithPanel="True"
+                       RelativePanel.AlignHorizontalCenterWithPanel="true"
+                       Margin="12"
+                       TextWrapping="Wrap"
+                       Text="{Binding Message}"/>
+            <Button x:Name="YesButton"
+                    RelativePanel.Below="MessageTextBlock"
+                    RelativePanel.AlignHorizontalCenterWithPanel="True"
+                    Content="YES"
+                    x:Uid="YesButtonText"
+                    Click="YesButtonClicked" />
+            <Button x:Name="NoButton"
+                    RelativePanel.Below="YesButton"
+                    RelativePanel.AlignHorizontalCenterWithPanel="True"
+                    Content="NO"
+                    x:Uid="NoButtonText"
+                    Click="NoButtonClicked"
+                    Background="Transparent"
+                    Foreground="#35908f"/>
+            <Button x:Name="OkButton"
+                    RelativePanel.Below="MessageTextBlock"
+                    RelativePanel.AlignHorizontalCenterWithPanel="True"
+                    Content="OK"
+                    x:Uid="OkButtonText"
+                    Click="OkButtonClicked"
+                    Visibility="Collapsed"/>
+        </RelativePanel>
+    </RelativePanel>
+</UserControl>

--- a/PokemonGo-UWP/Controls/Utils/MessageDialogChild.xaml.cs
+++ b/PokemonGo-UWP/Controls/Utils/MessageDialogChild.xaml.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using static PokemonGo_UWP.Controls.MessageDialog;
+
+namespace PokemonGo_UWP.Controls {
+    sealed partial class MessageDialogChild : UserControl {
+
+        #region Constructors
+
+        public MessageDialogChild(MessageDialogType type, String message) {
+            this.InitializeComponent();
+
+            // Workaround, otherwise message is not display
+            MessageTextBlock.Text = message;
+
+            this.Type = type;
+            this.Message = message;
+            this.Height = Window.Current.Bounds.Height;
+            this.Width = Window.Current.Bounds.Width;
+        }
+
+        #endregion
+
+        #region Shared Logic
+
+        private void ControlButtons() {
+            switch(Type) {
+                case MessageDialogType.OkOnly:
+                    YesButton.Visibility = Visibility.Collapsed;
+                    NoButton.Visibility = Visibility.Collapsed;
+                    OkButton.Visibility = Visibility.Visible;
+                    break;
+                case MessageDialogType.YesNo:
+                    YesButton.Visibility = Visibility.Visible;
+                    NoButton.Visibility = Visibility.Visible;
+                    OkButton.Visibility = Visibility.Collapsed;
+                    break;
+                default:
+                    throw new ArgumentException("The MessageDialogType '" + Type.ToString() + "' is currently not supported");
+            }
+        }
+
+        #endregion
+
+        public static readonly DependencyProperty MessageProperty = DependencyProperty.Register("InnerSegmentColor", typeof(string), typeof(CircularProgressBar), null);
+
+        #region Vars
+
+        public string Message
+        {
+            get { return (string)GetValue(MessageProperty); }
+            set { SetValue(MessageProperty, value); }
+        }
+
+        public MessageDialogType Type { get; private set; }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        ///     Event fired user pressed YES
+        /// </summary>
+        public event EventHandler YesButtonTapped;
+
+        /// <summary>
+        ///     Event fired user pressed NO
+        /// </summary>
+        public event EventHandler NoButtonTapped;
+
+        /// <summary>
+        ///     Event fired user pressed OK
+        /// </summary>
+        public event EventHandler OkButtonTapped;
+
+        #endregion
+
+        #region Event Handlers
+
+        private void YesButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e) {
+            YesButtonTapped?.Invoke(this, null);
+        }
+
+        private void NoButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e) {
+            NoButtonTapped?.Invoke(this, null);
+        }
+
+        private void OkButtonClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e) {
+            OkButtonTapped?.Invoke(this, null);
+        }
+
+
+        #endregion
+
+    }
+}

--- a/PokemonGo-UWP/Strings/en-US/Resources.resw
+++ b/PokemonGo-UWP/Strings/en-US/Resources.resw
@@ -269,4 +269,13 @@
   <data name="FavoriteTextBlock.Text" xml:space="preserve">
     <value>FAVORITE</value>
   </data>
+  <data name="NoButtonText.Content" xml:space="preserve">
+    <value>NO</value>
+  </data>
+  <data name="OkButtonText.Content" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="YesButtonText.Content" xml:space="preserve">
+    <value>YES</value>
+  </data>
 </root>


### PR DESCRIPTION

### Changes:

- Added Pokekom Go like Message Dialog

### Change details:
- Added a Pokemon Go Message Dialog to Display all Messages instead of using the Windows MessageDialog.
![message-dialog](https://cloud.githubusercontent.com/assets/20780000/17904334/40d44210-696f-11e6-923f-75210f7945bc.png)

### Other informations:
Please do not merge right now, because I'll Change all MessageDialogs to the new one.

Let me know, what do you think, guys. ;)
