### PR TITLE
Centered Pokestop Names & Login Form (In search pokestop & Main Page)

### DIFF
--- a/PokemonGo-UWP/Views/MainPage.xaml
+++ b/PokemonGo-UWP/Views/MainPage.xaml
@@ -33,14 +33,18 @@
                          Margin="15,20"
                          InputScope="EmailSmtpAddress"
                          Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         PlaceholderText="USERNAME / EMAIL" />
+                         PlaceholderText="USERNAME / EMAIL"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center" />
                 <PasswordBox x:Name="LoginPasswordPasswordBox"
                              x:Uid="LoginPasswordPasswordBox"
                              Style="{StaticResource PasswordBox}"
                              Margin="15,0"
                              KeyDown="passwordBox_KeyDown"
                              Password="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                             PlaceholderText="PASSWORD" />
+                             PlaceholderText="PASSWORD"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center" />
                 <CheckBox x:Name="RememberMeCheckBox"
                           x:Uid="RememberMeCheckBox"
                           IsChecked="{Binding RememberLoginData, Mode=TwoWay}"

--- a/PokemonGo-UWP/Views/MainPage.xaml
+++ b/PokemonGo-UWP/Views/MainPage.xaml
@@ -48,9 +48,11 @@
                 <CheckBox x:Name="RememberMeCheckBox"
                           x:Uid="RememberMeCheckBox"
                           IsChecked="{Binding RememberLoginData, Mode=TwoWay}"
-                          Margin="15,20,15,0">
+                          Margin="15,20,15,0"
+                          VerticalAlignment="Center"
+                          HorizontalAlignment="Center">
                     <TextBlock x:Uid="RememberMeTextBlock" 
-                               Text="REMEMBER ME" />
+                               Text="REMEMBER ME"/>
                 </CheckBox>
                 <Button x:Name="PtcLoginButton"
                         Style="{StaticResource ButtonSubmit}"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="PokemonGo_UWP.Views.SearchPokestopPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -110,7 +110,9 @@
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Style="{StaticResource GridContainer}">
                 <TextBlock Text="{Binding CurrentPokestopInfo.Name}"
-                           Style="{StaticResource TextPokestopTitle}" />
+                           Style="{StaticResource TextPokestopTitle}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"/>
             </Grid>
 
             <Border Grid.Row="1"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -112,7 +112,8 @@
                 <TextBlock Text="{Binding CurrentPokestopInfo.Name}"
                            Style="{StaticResource TextPokestopTitle}"
                            HorizontalAlignment="Center"
-                           VerticalAlignment="Center"/>
+                           VerticalAlignment="Center"
+                           Name="PokestopNameTag" />
             </Grid>
 
             <Border Grid.Row="1"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -21,6 +21,20 @@ namespace PokemonGo_UWP.Views
                 ShowGatheredItemsMenuAnimation.From = GatheredItemsTranslateTransform.Y = ActualHeight;
             };
         }
+        
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+                //PC customization
+                if(ApiInformation.IsTypePresent("Windows.UI.ViewManagement.ApplicationView"))
+                {
+                }
+
+                //Mobile customization
+                if(ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+                {
+                }
+        }
 
         #region Overrides of Page
 

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -28,11 +28,13 @@ namespace PokemonGo_UWP.Views
                 //PC customization
                 if(ApiInformation.IsTypePresent("Windows.UI.ViewManagement.ApplicationView"))
                 {
+                    PokestopNameTag.HorizontalAlignment = "Left";
                 }
 
                 //Mobile customization
                 if(ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
                 {
+                    PokestopNameTag.HorizontalAlignment = "Center";
                 }
         }
 


### PR DESCRIPTION
Closes issues
-------------
- Closes no issues

Changes
-------
- Centred the pokestop name and the login form elements on a vertical and horizontal axis

Change details
--------------
Did this so it looks better on desktop/ is properly aligned

Other informations
------------------
EDIT: I can update to work with #1538 if you like this change
![snapshot](https://cloud.githubusercontent.com/assets/20544390/17980627/198bfe3e-6af8-11e6-92ad-6dbe5d4676d8.png)
![snapshot](https://cloud.githubusercontent.com/assets/20544390/17981020/c38ef386-6af9-11e6-9e90-bc717a64001a.png)

