### PR TITLE
Fix possible login issues with expired token

### DIFF
--- a/PokemonGo-UWP/Package.appxmanifest
+++ b/PokemonGo-UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:wincap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities" IgnorableNamespaces="uap mp rescap wincap">
-  <Identity Name="c602d2cb-fdd8-4e41-b5a1-8f9a8a1f56c7" Publisher="CN=stept" Version="1.0.28.0" />
+  <Identity Name="c602d2cb-fdd8-4e41-b5a1-8f9a8a1f56c7" Publisher="CN=stept" Version="1.0.29.0" />
   <mp:PhoneIdentity PhoneProductId="c602d2cb-fdd8-4e41-b5a1-8f9a8a1f56c7" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>PoGo</DisplayName>

--- a/PokemonGo-UWP/Utils/GameClient.cs
+++ b/PokemonGo-UWP/Utils/GameClient.cs
@@ -390,6 +390,7 @@ namespace PokemonGo_UWP.Utils
                 if (e is PokemonGo.RocketAPI.Exceptions.AccessTokenExpiredException)
                 {
                     Debug.WriteLine("AccessTokenExpired Exception caught");
+                    _client.AccessToken.Expire();
                     await _client.Login.DoLogin();
                 }
                 else

--- a/PokemonGoAPI/Session/AccessToken.cs
+++ b/PokemonGoAPI/Session/AccessToken.cs
@@ -37,7 +37,7 @@ namespace PokemonGoAPI.Session
 
         public void Expire()
         {
-            Expiry = DateTime.UtcNow;
+            Expiry = DateTime.UtcNow.AddSeconds(-60);
             AuthTicket = null;
         }
     }

--- a/PokemonGoAPI/Session/AccessToken.cs
+++ b/PokemonGoAPI/Session/AccessToken.cs
@@ -30,7 +30,7 @@ namespace PokemonGoAPI.Session
         public AuthType AuthType { get; internal set; }
 
         [JsonIgnore]
-        public bool IsExpired => Expiry <= DateTime.UtcNow;
+        public bool IsExpired => Expiry.AddSeconds(-60) <= DateTime.UtcNow;
 
         [JsonIgnore]
         public AuthTicket AuthTicket { get; internal set; }

--- a/PokemonGoAPI/Session/AccessToken.cs
+++ b/PokemonGoAPI/Session/AccessToken.cs
@@ -30,7 +30,7 @@ namespace PokemonGoAPI.Session
         public AuthType AuthType { get; internal set; }
 
         [JsonIgnore]
-        public bool IsExpired => DateTime.UtcNow > Expiry;
+        public bool IsExpired => Expiry <= DateTime.UtcNow;
 
         [JsonIgnore]
         public AuthTicket AuthTicket { get; internal set; }


### PR DESCRIPTION
Changes
-------
- When AccessTokenExpiredException we forcibly Expire our token if .IsExpired in DoLogin somehow fails
- IsExpired is more optimistic with 60sec precheck to eliminate wire delay and heartbeat delay
- Set current version to 29 as is released

Change details
--------------
These changes are made as a precautionary solution for ppl getting banned maybe because of login loop.