### PR TITLE
show the autoupdate button only when the map is actually moved

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml.cs
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml.cs
@@ -14,6 +14,7 @@ using PokemonGo.RocketAPI;
 using PokemonGo_UWP.Utils;
 using Template10.Common;
 using Windows.Graphics.Display;
+using PokemonGo_UWP.Utils.Helpers;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -306,7 +307,8 @@ namespace PokemonGo_UWP.Views
 
         private void GameMapControl_TargetCameraChanged(MapControl sender, MapTargetCameraChangedEventArgs args)
         {
-            if (args.ChangeReason == MapCameraChangeReason.UserInteraction && lastAutoPosition != null)
+            var distance = GeoHelper.Distance(lastAutoPosition, args.Camera.Location);
+            if (args.ChangeReason == MapCameraChangeReason.UserInteraction && lastAutoPosition != null && distance > 0)
             {
                 ReactivateMapAutoUpdateButton.Visibility = Visibility.Visible;
             }


### PR DESCRIPTION
Closes issues
-------------
- if you press the tilt or autorotate button on the map, the autoupdate button appears;

Changes
-------
- check if the distance between lastAutoposition and the location of the map camera is greater than 0;
