### PR TITLE
(Enhancement) Add Busy for PokemonDetail awaiting dialogs

### DIFF
--- a/PokemonGoAPI/Interfaces/IApiFailureStrategy.cs
+++ b/PokemonGoAPI/Interfaces/IApiFailureStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using PokemonGoAPI.Enums;
 using POGOProtos.Networking.Envelopes;
 
 namespace PokemonGoAPI.Interfaces


### PR DESCRIPTION
Changes
-------
- Removes transfer result MessageDialog
- Adds Busy after confirmation of Transfer, Rename and Favorite

Change details
--------------
- When transfer happened, user had to wait until `MessageDialog`, which was cumbersome after to click on. Against official app our transfer was too slow process. We should only make some quick popup text to inform user that he got candy and not make him click to confirm.
- Busy dialogs are added because server sometimes takes some time to process the request and user didn't know that. With busy, user now knows. (On rename it sometimes didn't even propagate because of this)
- I also fixed the latest commit build. There were missing using in `IApiFailureStrategy.cs`

Other informations
------------------
Resources for :
- `TransferPokemonWarningTitle` and `TransferPokemonWarningText should be changed to incorporate, that transfer will result with 1 candy addition.
- `TransferPokemonSuccessText` should be removed, because it is not used anymore

If you could help me with steps how to set the resources so that they need change or to remove them, I would appreciate that.