### PR TITLE
Make ExpiresUtc not required for now.

### DIFF
--- a/PokemonGoAPI/Session/AccessToken.cs
+++ b/PokemonGoAPI/Session/AccessToken.cs
@@ -45,7 +45,7 @@ namespace PokemonGoAPI.Session
         /// <summary>
         /// The time this token expired in UTC.
         /// </summary>
-        [JsonProperty("expiresUtc", Required = Required.Always)]
+        [JsonProperty("expiresUtc")]
         public DateTime ExpiresUtc { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
Can add this back in later after everyone updates to the build that contains this fix.