### PR TITLE
Fixing visual bug on Pokedex

### DIFF
--- a/PokemonGo-UWP/ViewModels/PokedexPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokedexPageViewModel.cs
@@ -144,6 +144,9 @@ namespace PokemonGo_UWP.ViewModels
             (_openPokedexEntry = new DelegateCommand<KeyValuePair<PokemonId, PokedexEntry>>(
                 (x) => 
                     {
+                        // Check if Pokemon was never seen
+                        if(x.Value == null) return;
+
                         SelectedPokedexEntry = x;
                         RaisePropertyChanged(nameof(SelectedPokedexEntry));
                         IsPokemonDetailsOpen = true;

--- a/PokemonGo-UWP/Views/PokedexPage.xaml
+++ b/PokemonGo-UWP/Views/PokedexPage.xaml
@@ -62,12 +62,6 @@
             <Grid MinWidth="64" 
                   MinHeight="64"
                   Padding="8">
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Tapped">
-                        <core:InvokeCommandAction Command="{Binding DataContext.OpenPokedexEntry, ElementName=page}"
-                                                  CommandParameter="{Binding}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
                 <Image Stretch="Uniform"
                        VerticalAlignment="Center"
                        HorizontalAlignment="Center"
@@ -82,12 +76,6 @@
                   CornerRadius="5"
                   Padding="8"
                   Background="#d8cefd">
-                <interactivity:Interaction.Behaviors>
-                    <core:EventTriggerBehavior EventName="Tapped">
-                        <core:InvokeCommandAction Command="{Binding DataContext.OpenPokedexEntry, ElementName=page}"
-                                                  CommandParameter="{Binding}" />
-                    </core:EventTriggerBehavior>
-                </interactivity:Interaction.Behaviors>
                 <BitmapIcon
                     UriSource="{Binding Key, Converter={StaticResource PokemonIdToPokemonSpriteConverter}, ConverterParameter=uri}"
                     VerticalAlignment="Center"
@@ -201,24 +189,29 @@
             </StackPanel>
 
             <GridView x:Name="pokeindex"
-                          ItemsSource="{Binding PokemonFoundAndSeen}"
-                          Canvas.ZIndex="0"
-                          Grid.Row="1"
-                          HorizontalAlignment="Stretch"
-                          ScrollViewer.VerticalScrollMode="Auto"
-                          ScrollViewer.VerticalScrollBarVisibility="Auto">
-                
+                      ItemsSource="{Binding PokemonFoundAndSeen}"
+                      Canvas.ZIndex="0"
+                      Grid.Row="1"
+                      HorizontalAlignment="Stretch"
+                      ScrollViewer.VerticalScrollMode="Auto"
+                      ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                      SelectionMode="None" 
+                      IsItemClickEnabled="True"
+                      ItemClick="Pokeindex_ItemClick">
+
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>
                         <ItemsWrapGrid Orientation="Horizontal"
-                                           HorizontalAlignment="Center"
-                                           MaximumRowsOrColumns="6" />
+                                       HorizontalAlignment="Center"
+                                       MaximumRowsOrColumns="6" />
                     </ItemsPanelTemplate>
                 </GridView.ItemsPanel>
 
                 <GridView.ItemContainerStyle>
-                    <Style TargetType="FrameworkElement">
+                    <Style TargetType="GridViewItem">
                         <Setter Property="Margin" Value="2"/>
+                        <Setter Property="MaxWidth" Value="64"/>
+                        <Setter Property="MaxHeight" Value="64"/>
                     </Style>
                 </GridView.ItemContainerStyle>
 

--- a/PokemonGo-UWP/Views/PokedexPage.xaml.cs
+++ b/PokemonGo-UWP/Views/PokedexPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using PokemonGo_UWP.Utils;
+using PokemonGo_UWP.ViewModels;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -25,6 +26,11 @@ namespace PokemonGo_UWP.Views
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+        }
+
+        private void Pokeindex_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            ((PokedexPageViewModel)DataContext).OpenPokedexEntry.Execute(e.ClickedItem);
         }
     }
 }


### PR DESCRIPTION
Closes issues
-------------
Resolves visual bug that occurred only to some user (like @chatfix ) leading to the Pokédex view being unusable.

Changes
-------
- Improved clickable area of Pokédex entries

Change details
--------------
- Removed click event from templates and moved to GridView containing them
- Set MaxWidth and MaxHeight for the ItemContainerStyle

Other informations
------------------
Due to this change, there is now a border visible when hovering over the entries. Should be fixed later on with a custom style an template.