### PR TITLE
Fix when pokeballs goes to 0, they didn't change to next available

### DIFF
--- a/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
@@ -375,7 +375,11 @@ namespace PokemonGo_UWP.ViewModels
             if (itemId == null)
                 return null;
 
-            return ItemsInventory?.FirstOrDefault(item => item.ItemId == itemId);
+            var ball = ItemsInventory?.FirstOrDefault(item => item.ItemId == itemId);
+            if (ball == null || ball.Count <= 0)
+                return null;
+
+            return ball;
         }
 
         private DelegateCommand<bool> _useSelectedCaptureItem;


### PR DESCRIPTION
Changes
-------
- Added check to 0 pokeballs when selecting the same type

Change details
--------------
When I ran out of pokeballs, they didn't change to next type automatically, because `SelectPokeballType` function returned the same type with `.Count == 0` so the line after throw:
`SelectedCaptureItem = SelectPokeballType(LastItemUsed) ?? SelectAvailablePokeBall()` didn't change pokeball type to the next.
Now when `SelectPokeballType` returns null when .Count is 0 it works fine.