### PR TITLE
Updated "nb-NO" and "nn-NO" translations

### DIFF
--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
@@ -89,35 +89,35 @@
       <group id="POKEMONGO-UWP/STRINGS/EN-US/ITEMS.RESW" datatype="resx">
         <trans-unit id="D_ItemGreatBall" translate="yes" xml:space="preserve">
           <source>A good, high-performance Poké Ball that provides a higher catch rate than a standard Poké Ball.</source>
-          <target state="translated">En Poké Ball med høy ytelse som gir større sjanse for å fange Pokémon enn en standard Poké Ball.</target>
+          <target state="final">En ball med bedre ytelse enn en standard Poké Ball. Denne ballen gir deg større sjanse for å fange en Pokémon.</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseCool" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseFloral" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseOrdinary" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseSpicy" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncubatorBasic" translate="yes" xml:space="preserve">
           <source>A device that incubates an Egg as you walk until it is ready to hatch. Breaks after 3 uses.</source>
-          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes.</target>
+          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes. Den kan brukes tre ganger.</target>
         </trans-unit>
         <trans-unit id="D_ItemIncubatorBasicUnlimited" translate="yes" xml:space="preserve">
           <source>A device that incubates an Egg as you walk until it is ready to hatch. Unlimited use!</source>
-          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes.</target>
+          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes. Den har evig bruk.</target>
         </trans-unit>
         <trans-unit id="D_ItemMasterBall" translate="yes" xml:space="preserve">
           <source>The best Poké Ball with the ultimate level of performance. With it you will catch any Pokémon without fail.</source>
-          <target state="translated">Den beste Poké Ballen du kan få. Med denne Poké Ballen kan du fange hvilken som helst Pokémon uten å mislykkes.</target>
+          <target state="final">Den beste Poké Ballen du kan få. Med denne Poké Ballen kan du fange hvilken som helst Pokémon uten å mislykkes.</target>
         </trans-unit>
         <trans-unit id="D_ItemPokeBall" translate="yes" xml:space="preserve">
           <source>A device for capturing wild Pokémon. It's thrown like a ball at a wild Pokémon, comfortably encapsulating its target.</source>
@@ -125,7 +125,7 @@
         </trans-unit>
         <trans-unit id="D_ItemPotion" translate="yes" xml:space="preserve">
           <source>A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 20 points.</source>
-          <target state="final">En spray-type medisin for behandling av sår. Det gjenoppretter HP av en Pokémon med 20 poeng.</target>
+          <target state="final">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 20 poeng.</target>
         </trans-unit>
         <trans-unit id="D_ItemRevive" translate="yes" xml:space="preserve">
           <source>A medicine that can revive fainted Pokémon. It also restores half of a fainted Pokémon's maximum HP.</source>
@@ -133,7 +133,7 @@
         </trans-unit>
         <trans-unit id="D_ItemUltraBall" translate="yes" xml:space="preserve">
           <source>An ultra-high performance Poké Ball that provides a higher success rate for catching Pokémon than a Great.</source>
-          <target state="translated">En Poké Ball av super kvalitet som gir deg stor skjanse for å fange en Pokémon. Den er enda bedre enn en Great Ball.</target>
+          <target state="final">En Poké Ball av super kvalitet som gir deg stor skjanse for å fange en Pokémon. Den er enda bedre enn en Great Ball.</target>
         </trans-unit>
         <trans-unit id="ItemBlukBerry" translate="yes" xml:space="preserve">
           <source>Bluk Berry</source>
@@ -145,23 +145,23 @@
         </trans-unit>
         <trans-unit id="ItemHyperPotion" translate="yes" xml:space="preserve">
           <source>Hyper Potion</source>
-          <target state="final">Hyper Potion</target>
+          <target state="needs-review-translation">Hyper Potion</target>
         </trans-unit>
         <trans-unit id="ItemIncenseCool" translate="yes" xml:space="preserve">
           <source>Cool Incense</source>
-          <target state="final">Cool Incense</target>
+          <target state="needs-review-translation">Cool Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseFloral" translate="yes" xml:space="preserve">
           <source>Floral Incense</source>
-          <target state="final">Floral Incense</target>
+          <target state="needs-review-translation">Floral Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseOrdinary" translate="yes" xml:space="preserve">
           <source>Incense</source>
-          <target state="final">Incense</target>
+          <target state="needs-review-translation">Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseSpicy" translate="yes" xml:space="preserve">
           <source>Spicy Incense</source>
-          <target state="final">Spicy Incense</target>
+          <target state="needs-review-translation">Spicy Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncubatorBasic" translate="yes" xml:space="preserve">
           <source>Incubator</source>
@@ -173,7 +173,7 @@
         </trans-unit>
         <trans-unit id="ItemItemStorageUpgrade" translate="yes" xml:space="preserve">
           <source>Item Storage Upgrade</source>
-          <target state="final">Gjenstand lager oppgradering</target>
+          <target state="final">Gjenstands lager oppgradering</target>
         </trans-unit>
         <trans-unit id="ItemLuckyEgg" translate="yes" xml:space="preserve">
           <source>Lucky Egg</source>
@@ -205,7 +205,7 @@
         </trans-unit>
         <trans-unit id="ItemPokemonStorageUpgrade" translate="yes" xml:space="preserve">
           <source>Pokemon Storage Upgrade</source>
-          <target state="final">Pokémon lager oppgradering</target>
+          <target state="final">Pokélager oppgradering</target>
         </trans-unit>
         <trans-unit id="ItemPotion" translate="yes" xml:space="preserve">
           <source>Potion</source>
@@ -221,7 +221,7 @@
         </trans-unit>
         <trans-unit id="ItemSpecialCamera" translate="yes" xml:space="preserve">
           <source>Special Camera</source>
-          <target state="final">Spesial Kamera</target>
+          <target state="needs-review-translation">Spesial Kamera</target>
         </trans-unit>
         <trans-unit id="ItemSuperPotion" translate="yes" xml:space="preserve">
           <source>Super Potion</source>
@@ -257,43 +257,43 @@
         </trans-unit>
         <trans-unit id="D_ItemLuckyEgg" translate="yes" xml:space="preserve">
           <source>A Lucky Egg that's filled with happiness! Earns double XP for 30 minutes.</source>
-          <target state="translated">Et Egg som er fylt med lykke! Du får dobbel XP i 30 minutter.</target>
+          <target state="final">Et Egg fylt med lykke! Du får dobbel XP i 30 minutter.</target>
         </trans-unit>
         <trans-unit id="D_ItemRazzBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemSpecialCamera" translate="yes" xml:space="preserve">
           <source>When you encounter Pokémon in the wild, you can use your camera to photograph them.</source>
-          <target state="translated">Når du støter Pokémon i naturen kan du bruke kameraet til å fotografere dem.</target>
+          <target state="final">Når du støter Pokémon i naturen kan du bruke kameraet til å fotografere dem.</target>
         </trans-unit>
         <trans-unit id="D_ItemSuperPotion" translate="yes" xml:space="preserve">
           <source>A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 50 points.</source>
-          <target state="translated">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 50 poeng.</target>
+          <target state="final">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 50 poeng.</target>
         </trans-unit>
         <trans-unit id="D_ItemTroyDisk" translate="yes" xml:space="preserve">
           <source>A module that attracts Pokémon to a Pokéstop for 30 min. The effect benefits other people nearby.</source>
-          <target state="translated">En modul som tiltrekker Pokémon til et Pokéstop i 30 minutter. Andre spillere kan også ta nytte av effekten.</target>
+          <target state="final">En modul som tiltrekker Pokémon til et Pokéstop i 30 minutter. Andre spillere kan også ta nytte av effekten.</target>
         </trans-unit>
         <trans-unit id="D_ItemUnknown" translate="yes" xml:space="preserve">
           <source>This item is unknown and may be added in the future.</source>
-          <target state="translated">Denne gjenstanden er ukjent og vil kanskje legges til i fremtiden.</target>
+          <target state="final">Denne gjenstanden er ukjent og vil kanskje legges til i fremtiden.</target>
         </trans-unit>
         <trans-unit id="D_ItemBlukBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemNanabBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemPinapBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemWeparBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
       </group>
     </body>
@@ -322,7 +322,7 @@
         </trans-unit>
         <trans-unit id="LoginDisclaimerTextBox.Text" translate="yes" xml:space="preserve">
           <source>To login, enter your Username/Email and Password above. If you don't trust this app, please close it now. Niantic may ban you for using this app. Use at your own risk.</source>
-          <target state="final">For å logge inn, må du oppgi Brukernavn/E-post og Passord ovenfor. Hvis du ikke stoler på appen, vennligst lukk den nå. Niantic kan utestenge deg om du bruker appen. Bruk på eget ansvar.</target>
+          <target state="final">For å logge på må du oppgi Brukernavn/E-post og Passord ovenfor. Hvis du ikke stoler på appen, vennligst lukk den nå. Niantic kan utestenge deg om du bruker appen. Bruk på eget ansvar.</target>
         </trans-unit>
         <trans-unit id="NearbyPokemonTextBlock.Text" translate="yes" xml:space="preserve">
           <source>nearby</source>
@@ -420,7 +420,7 @@
         </trans-unit>
         <trans-unit id="StartDateTextBlock.Text" translate="yes" xml:space="preserve">
           <source>START DATE</source>
-          <target state="final">START DATO</target>
+          <target state="final">STARTDATO</target>
         </trans-unit>
         <trans-unit id="IncubatorsTextBlock.Text" translate="yes" xml:space="preserve">
           <source>INCUBATORS</source>
@@ -477,7 +477,7 @@
         </trans-unit>
         <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Use an incubator to incubate the Egg.</source>
-          <target state="final">Bruk en inkubator for å klekke Egget.</target>
+          <target state="final">Bruk en Inkubator for å klekke Egget.</target>
         </trans-unit>
         <trans-unit id="PokedexCaught.Text" translate="yes" xml:space="preserve">
           <source>Caught:</source>
@@ -521,7 +521,7 @@
         </trans-unit>
         <trans-unit id="SettingsRememberMapZoomTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Remember Map Zoom</source>
-          <target state="final">Husk Kart Zoom</target>
+          <target state="needs-review-translation">Husk Kart Zoom</target>
         </trans-unit>
         <trans-unit id="TransferTextBlock.Text" translate="yes" xml:space="preserve">
           <source>TRANSFER</source>
@@ -533,7 +533,7 @@
         </trans-unit>
         <trans-unit id="SettingsLanguageTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="final">Sprøk</target>
+          <target state="final">Språk</target>
         </trans-unit>
         <trans-unit id="SettingsCompassEnabledTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Use compass</source>
@@ -541,7 +541,7 @@
         </trans-unit>
         <trans-unit id="SettingsLiveTileTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Live Tile Mode</source>
-          <target state="final">Live Flis Modus</target>
+          <target state="final">Live Flis</target>
         </trans-unit>
         <trans-unit id="FavoriteTextBlock.Text" translate="yes" xml:space="preserve">
           <source>FAVORITE</source>
@@ -549,12 +549,12 @@
         </trans-unit>
         <trans-unit id="AppraiseTextBlock.Text" translate="yes" xml:space="preserve">
           <source>APPRAISE</source>
-          <target state="new">APPRAISE</target>
+          <target state="needs-review-translation">UNDERSØK</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="AwardedExperienceTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Experience</source>
-          <target state="new">Experience</target>
+          <target state="new">XP</target>
         </trans-unit>
       </group>
     </body>
@@ -567,227 +567,227 @@
       <group id="POKEMONGO-UWP/STRINGS/EN-US/ACHIEVEMENTS.RESW" datatype="resx">
         <trans-unit id="BadgeBattleAttackWon" translate="yes" xml:space="preserve">
           <source>Battle Girl</source>
-          <target state="translated">Utfordrer</target>
+          <target state="final">Utfordrer</target>
         </trans-unit>
         <trans-unit id="BadgeBattleAttackWonDescription" translate="yes" xml:space="preserve">
           <source>Won {0} gym battles</source>
-          <target state="translated">{0} Pokégym Kamper Vunnet</target>
+          <target state="final">{0} Pokégym Kamper Vunnet</target>
         </trans-unit>
         <trans-unit id="BadgeBattleTrainingWon" translate="yes" xml:space="preserve">
           <source>Ace Trainer</source>
-          <target state="translated">Erfaren trener</target>
+          <target state="final">Profesjonell</target>
         </trans-unit>
         <trans-unit id="BadgeBattleTrainingWonDescription" translate="yes" xml:space="preserve">
           <source>Won {0} training battles</source>
-          <target state="translated">{0} Treningskamper Vunnet</target>
+          <target state="final">{0} Treningskamper Vunnet</target>
         </trans-unit>
         <trans-unit id="BadgeBigMagikarp" translate="yes" xml:space="preserve">
           <source>Fisherman</source>
-          <target state="translated">Fisker</target>
+          <target state="final">Fisker</target>
         </trans-unit>
         <trans-unit id="BadgeBigMagikarpDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Magikarp</source>
-          <target state="translated">{0} Magikarp fanget</target>
+          <target state="final">{0} Magikarp fanget</target>
         </trans-unit>
         <trans-unit id="BadgeCaptureTotal" translate="yes" xml:space="preserve">
           <source>Collector</source>
-          <target state="translated">Samler</target>
+          <target state="final">Samler</target>
         </trans-unit>
         <trans-unit id="BadgeCaptureTotalDescription" translate="yes" xml:space="preserve">
           <source>Captured {0} Pokemon</source>
-          <target state="translated">{0} Pokémon fanget</target>
+          <target state="final">{0} Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="BadgeEvolvedTotal" translate="yes" xml:space="preserve">
           <source>Scientist</source>
-          <target state="translated">Forsker</target>
+          <target state="final">Forsker</target>
         </trans-unit>
         <trans-unit id="BadgeEvolvedTotalDescription" translate="yes" xml:space="preserve">
           <source>Evolved {0} Pokémon</source>
-          <target state="translated">{0} Pokémon utviklet</target>
+          <target state="final">{0} Pokémon utviklet</target>
         </trans-unit>
         <trans-unit id="BadgeHatchedTotal" translate="yes" xml:space="preserve">
           <source>Breeder</source>
-          <target state="translated">Oppdretter</target>
+          <target state="final">Oppdretter</target>
         </trans-unit>
         <trans-unit id="BadgeHatchedTotalDescription" translate="yes" xml:space="preserve">
           <source>Hatched {0} Pokemon</source>
-          <target state="translated">{0} Pokémon klekket</target>
+          <target state="final">{0} Pokémon klekket</target>
         </trans-unit>
         <trans-unit id="BadgePikachu" translate="yes" xml:space="preserve">
           <source>Pikachu</source>
-          <target state="translated">Pikachu Fan</target>
+          <target state="final">Pikachu Fan</target>
         </trans-unit>
         <trans-unit id="BadgePikachuDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Pikachu</source>
-          <target state="translated">{0} Pikachu fanget</target>
+          <target state="final">{0} Pikachu fanget</target>
         </trans-unit>
         <trans-unit id="BadgePokedexEntries" translate="yes" xml:space="preserve">
           <source>Kanto</source>
-          <target state="translated">Oppdager</target>
+          <target state="final">Oppdager</target>
         </trans-unit>
         <trans-unit id="BadgePokedexEntriesDescription" translate="yes" xml:space="preserve">
           <source>Registered {0} Pokemon in the Pokedex</source>
-          <target state="translated">{0} Pokémon registrert i Pokédexen</target>
+          <target state="final">{0} Pokémon registrert i Pokédexen</target>
         </trans-unit>
         <trans-unit id="BadgePokestopsVisited" translate="yes" xml:space="preserve">
           <source>Backpacker</source>
-          <target state="translated">Dårlig Tid?</target>
+          <target state="final">Hyppig</target>
         </trans-unit>
         <trans-unit id="BadgePokestopsVisitedDescription" translate="yes" xml:space="preserve">
           <source>Visited {0} Pokestops</source>
-          <target state="translated">{0} Pokéstop Besøkt</target>
+          <target state="final">{0} Pokéstop Besøkt</target>
         </trans-unit>
         <trans-unit id="BadgeSmallRattata" translate="yes" xml:space="preserve">
           <source>Youngster</source>
-          <target state="translated">Unggutt</target>
+          <target state="final">Unggutt</target>
         </trans-unit>
         <trans-unit id="BadgeSmallRattataDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} small Rattata</source>
-          <target state="translated">{0} Små Rattata fanget</target>
+          <target state="final">{0} Små Rattata fanget</target>
         </trans-unit>
         <trans-unit id="BadgeTravelKm" translate="yes" xml:space="preserve">
           <source>Jogger</source>
-          <target state="translated">Jogger</target>
+          <target state="final">Jogger</target>
         </trans-unit>
         <trans-unit id="BadgeTravelKmDescription" translate="yes" xml:space="preserve">
           <source>Walked {0} km</source>
-          <target state="translated">{0} km gått</target>
+          <target state="final">{0} km gått</target>
         </trans-unit>
         <trans-unit id="Bug" translate="yes" xml:space="preserve">
           <source>Bug Catcher</source>
-          <target state="translated">Insektfanger</target>
+          <target state="final">Insektfanger</target>
         </trans-unit>
         <trans-unit id="BugDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Bug Pokemon</source>
-          <target state="translated">{0} Insekt-type Pokémon fanget</target>
+          <target state="final">{0} Insekt-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Dragon" translate="yes" xml:space="preserve">
           <source>Dragon Tamer</source>
-          <target state="translated">Dragetemmer</target>
+          <target state="final">Dragetemmer</target>
         </trans-unit>
         <trans-unit id="DragonDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Dragon Pokemon</source>
-          <target state="translated">{0} Drage-type Pokémon fanget</target>
+          <target state="final">{0} Drage-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Electric" translate="yes" xml:space="preserve">
           <source>Rocker</source>
-          <target state="translated">Elektriker</target>
+          <target state="final">Elektriker</target>
         </trans-unit>
         <trans-unit id="ElectricDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Electric Pokemon</source>
-          <target state="translated">{0} Elektrisk-type Pokémon fanget</target>
+          <target state="final">{0} Elektrisk-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fairy" translate="yes" xml:space="preserve">
           <source>Fairy Tale Girl</source>
-          <target state="translated">Eventyrtid</target>
+          <target state="final">Eventyrtid</target>
         </trans-unit>
         <trans-unit id="FairyDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fairy Pokemon</source>
-          <target state="translated">{0} Fe-type Pokémon fanget</target>
+          <target state="final">{0} Fe-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fighting" translate="yes" xml:space="preserve">
           <source>Black Belt</source>
-          <target state="translated">Svart Belte</target>
+          <target state="final">Svart Belte</target>
         </trans-unit>
         <trans-unit id="FightingDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fighting Pokemon</source>
-          <target state="translated">{0} Sloss-type Pokémon fanget</target>
+          <target state="final">{0} Sloss-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fire" translate="yes" xml:space="preserve">
           <source>Kindler</source>
-          <target state="translated">Pyroman</target>
+          <target state="final">Pyroman</target>
         </trans-unit>
         <trans-unit id="FireDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fire Pokemon</source>
-          <target state="translated">{0} Brann-type Pokémon fanget</target>
+          <target state="final">{0} Brann-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Flying" translate="yes" xml:space="preserve">
           <source>Bird Keeper</source>
-          <target state="translated">Fuglepasser</target>
+          <target state="final">Fuglepasser</target>
         </trans-unit>
         <trans-unit id="FlyingDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Flying Pokemon</source>
-          <target state="translated">{0} Fly-type Pokémon fanget</target>
+          <target state="final">{0} Fly-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ghost" translate="yes" xml:space="preserve">
           <source>Hex Maniac</source>
-          <target state="translated">Spøkelsesjeger</target>
+          <target state="final">Spøkelsesjeger</target>
         </trans-unit>
         <trans-unit id="GhostDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ghost Pokemon</source>
-          <target state="translated">{0} Spøkelse-type Pokémon fanget</target>
+          <target state="final">{0} Spøkelse-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Grass" translate="yes" xml:space="preserve">
           <source>Gardener</source>
-          <target state="translated">Gartner</target>
+          <target state="final">Gartner</target>
         </trans-unit>
         <trans-unit id="GrassDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Grass Pokemon</source>
-          <target state="translated">{0} Gress-type Pokémon fanget</target>
+          <target state="final">{0} Gress-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ground" translate="yes" xml:space="preserve">
           <source>Ruin Maniac</source>
-          <target state="translated">Under Jorden</target>
+          <target state="final">Underjordisk</target>
         </trans-unit>
         <trans-unit id="GroundDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ground Pokemon</source>
-          <target state="translated">{0} Jord-type Pokémon fanget</target>
+          <target state="final">{0} Jord-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ice" translate="yes" xml:space="preserve">
           <source>Skier</source>
-          <target state="translated">Skiløper</target>
+          <target state="final">Skiløper</target>
         </trans-unit>
         <trans-unit id="IceDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ice Pokemon</source>
-          <target state="translated">{0} Is-type Pokémon fanget</target>
+          <target state="final">{0} Is-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Normal" translate="yes" xml:space="preserve">
           <source>School Kid</source>
-          <target state="translated">Skoleelev</target>
+          <target state="final">Skoleelev</target>
         </trans-unit>
         <trans-unit id="NormalDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Normal Pokemon</source>
-          <target state="translated">{0} Normal-type Pokémon fanget</target>
+          <target state="final">{0} Normal-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Poison" translate="yes" xml:space="preserve">
           <source>Punk Girl</source>
-          <target state="translated">Giftig Samling</target>
+          <target state="final">Giftig</target>
         </trans-unit>
         <trans-unit id="PoisonDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Poison Pokemon</source>
-          <target state="translated">{0} Gift-type Pokémon fanget</target>
+          <target state="final">{0} Gift-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Psychic" translate="yes" xml:space="preserve">
           <source>Psychic</source>
-          <target state="translated">Psykiater</target>
+          <target state="final">Psykiater</target>
         </trans-unit>
         <trans-unit id="PsychicDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Psychic Pokemon</source>
-          <target state="translated">{0} Psykisk-type Pokémon fanget</target>
+          <target state="final">{0} Psykisk-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Rock" translate="yes" xml:space="preserve">
           <source>Hiker</source>
-          <target state="translated">Turgåer</target>
+          <target state="final">Turgåer</target>
         </trans-unit>
         <trans-unit id="RockDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Rock Pokemon</source>
-          <target state="translated">{0} Stein-type Pokémon fanget</target>
+          <target state="final">{0} Stein-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Steel" translate="yes" xml:space="preserve">
           <source>Depot Agent</source>
-          <target state="translated">Metallarbeider</target>
+          <target state="final">Mekaniker</target>
         </trans-unit>
         <trans-unit id="SteelDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Steel Pokemon</source>
-          <target state="translated">{0} Metall-type Pokémon fanget</target>
+          <target state="final">{0} Metall-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Water" translate="yes" xml:space="preserve">
           <source>Swimmer</source>
-          <target state="translated">Svømmer</target>
+          <target state="final">Svømmer</target>
         </trans-unit>
         <trans-unit id="WaterDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Water Pokemon</source>
-          <target state="translated">{0} Vann-type Pokémon fanget</target>
+          <target state="final">{0} Vann-type Pokémon fanget</target>
         </trans-unit>
       </group>
     </body>
@@ -808,36 +808,36 @@
         </trans-unit>
         <trans-unit id="PokemonFledText" translate="yes" xml:space="preserve">
           <source>{0} fled</source>
-          <target state="translated">{0} flyktet
+          <target state="final">{0} flyktet
 </target>
         </trans-unit>
         <trans-unit id="GettingGpsSignalText" translate="yes" xml:space="preserve">
           <source>Getting GPS signal...</source>
-          <target state="translated">Søker GPS signal...</target>
+          <target state="final">Søker GPS signal...</target>
         </trans-unit>
         <trans-unit id="GettingUserDataText" translate="yes" xml:space="preserve">
           <source>Getting user data...</source>
-          <target state="translated">Henter brukerdata...</target>
+          <target state="final">Henter brukerdata...</target>
         </trans-unit>
         <trans-unit id="GoogleErrorText" translate="yes" xml:space="preserve">
           <source>Google returned error: </source>
-          <target state="translated">Google returnerte feil: </target>
+          <target state="final">Google returnerte feil: </target>
         </trans-unit>
         <trans-unit id="GoogleNotRespondingText" translate="yes" xml:space="preserve">
           <source>Google is not responding, please try again later.</source>
-          <target state="translated">Google svarer ikke, vennligst prøv igjen senere.</target>
+          <target state="final">Google svarer ikke, vennligst prøv igjen senere.</target>
         </trans-unit>
         <trans-unit id="LoginExpired" translate="yes" xml:space="preserve">
           <source>Previous login expired.</source>
-          <target state="translated">Tidligere innlogging har utløpt.</target>
+          <target state="final">Tidligere pålogging har utløpt.</target>
         </trans-unit>
         <trans-unit id="LoadingEncounterText" translate="yes" xml:space="preserve">
           <source>Loading encounter with {0}</source>
-          <target state="translated">Laster møte med {0}</target>
+          <target state="final">Laster møte med {0}</target>
         </trans-unit>
         <trans-unit id="LoggingInText" translate="yes" xml:space="preserve">
           <source>Logging in...</source>
-          <target state="final">Logger inn...</target>
+          <target state="final">Logger på...</target>
         </trans-unit>
         <trans-unit id="LoginFailedText" translate="yes" xml:space="preserve">
           <source>Login failed, please try again.</source>
@@ -845,25 +845,24 @@
         </trans-unit>
         <trans-unit id="NoText" translate="yes" xml:space="preserve">
           <source>NO</source>
-          <target state="needs-review-translation">Nei</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">NEI</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="NoGpsPermissionsText" translate="yes" xml:space="preserve">
           <source>We need GPS permissions to run the game, please enable it and try again.</source>
-          <target state="translated">Vi trenger GPS tillatelse for å starte spillet, vennligst aktiver det og prøv på nytt.</target>
+          <target state="final">Vi trenger GPS tillatelse for å starte spillet, vennligst aktiver det og prøv på nytt.</target>
         </trans-unit>
         <trans-unit id="PokemonRanAwayText" translate="yes" xml:space="preserve">
           <source>Pokémon ran away, sorry :(</source>
-          <target state="translated">Pokémonen rømte, beklager :(</target>
+          <target state="final">Pokémonen rømte, beklager :(</target>
         </trans-unit>
         <trans-unit id="PtcDownText" translate="yes" xml:space="preserve">
           <source>PTC login is probably down, please retry later.</source>
-          <target state="translated">PTC pålogging er sannsynligvis nede, vennligst prøv på nytt senere.</target>
+          <target state="final">PTC påloggingen er sannsynligvis nede, vennligst prøv på nytt senere.</target>
         </trans-unit>
         <trans-unit id="SomethingWentWrongText" translate="yes" xml:space="preserve">
           <source>Something went wrong and app may be unstable now. Do you want to logout and try again?</source>
-          <target state="translated">Noe gikk galt og appen kan være ustabil. Vil du å logge ut og prøve på nytt?</target>
+          <target state="final">Noe gikk galt og appen kan være ustabil. Vil du logge ut og prøve på nytt?</target>
         </trans-unit>
         <trans-unit id="TimeFormat" translate="yes" xml:space="preserve">
           <source>hh:mm tt</source>
@@ -876,27 +875,26 @@
         <trans-unit id="UpdatedVersionText" translate="yes" xml:space="preserve">
           <source>An updated version {0} is available. Do you want to update?
 {1}</source>
-          <target state="translated">En oppdatert versjon {0} er tilgjengelig. Vil du oppdatere?
+          <target state="final">En oppdatert versjon {0} er tilgjengelig. Vil du oppdatere?
 {1}</target>
         </trans-unit>
         <trans-unit id="UpdateFailedText" translate="yes" xml:space="preserve">
           <source>Update failed: {0}
 Open page with installation files for manual install?</source>
-          <target state="translated">Oppdatering mislykkes: {0}
+          <target state="final">Oppdatering mislykkes: {0}
 Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target>
         </trans-unit>
         <trans-unit id="UpdateInstallingText" translate="yes" xml:space="preserve">
           <source>Installing update, app is restarting...</source>
-          <target state="translated">Installerer oppdatering, appen starter på nytt...</target>
+          <target state="final">Installerer oppdatering, appen starter på nytt...</target>
         </trans-unit>
         <trans-unit id="WrongUsernameText" translate="yes" xml:space="preserve">
           <source>Wrong username/password or offline server, please try again.</source>
-          <target state="translated">Feil brukernavn/passord eller frakoblet server, vennligst prøv på nytt.</target>
+          <target state="final">Feil brukernavn/passord eller offline server, vennligst prøv på nytt.</target>
         </trans-unit>
         <trans-unit id="YesText" translate="yes" xml:space="preserve">
           <source>YES</source>
-          <target state="needs-review-translation">Ja</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">JA</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="InstinctTeamText" translate="yes" xml:space="preserve">
@@ -905,7 +903,7 @@ Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target
         </trans-unit>
         <trans-unit id="NoTeamText" translate="yes" xml:space="preserve">
           <source>No Team</source>
-          <target state="final">Ingen lag</target>
+          <target state="final">Ingen Lag</target>
         </trans-unit>
         <trans-unit id="ValorTeamText" translate="yes" xml:space="preserve">
           <source>Valor</source>
@@ -917,177 +915,177 @@ Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target
         </trans-unit>
         <trans-unit id="TransferPokemonSuccessText" translate="yes" xml:space="preserve">
           <source>Transfer succeeded! Got a {0} Candy from the Professor.</source>
-          <target state="translated">Overføring fullført! Du fikk en {0} Candy fra Professoren.</target>
+          <target state="final">Overføring fullført! Du fikk en {0} Candy fra Professoren.</target>
         </trans-unit>
         <trans-unit id="TransferPokemonWarningText" translate="yes" xml:space="preserve">
           <source>You can't take it back after it's transferred to the Professor.</source>
-          <target state="translated">Du kan ikke få den tilbake etter den er overført til Professoren.</target>
+          <target state="final">Du kan ikke få den tilbake etter den er overført til Professoren.</target>
         </trans-unit>
         <trans-unit id="ActivityUnknown" translate="yes" xml:space="preserve">
           <source>Unknown</source>
-          <target state="translated">Ukjent</target>
+          <target state="final">Ukjent</target>
         </trans-unit>
         <trans-unit id="ActivityCatchPokemon" translate="yes" xml:space="preserve">
           <source>Pokémon Caught</source>
-          <target state="translated">Pokémon Fanget</target>
+          <target state="final">Pokémon Fanget</target>
         </trans-unit>
         <trans-unit id="ActivityCatchLegendPokemon" translate="yes" xml:space="preserve">
           <source>Catch Legendary Pokémon</source>
-          <target state="translated">Fang en Legendarisk Pokémon</target>
+          <target state="final">Fang en Legendarisk Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityFleePokemon" translate="yes" xml:space="preserve">
           <source>Pokémon Fled</source>
-          <target state="translated">Pokémonen Flyktet</target>
+          <target state="final">Pokémonen Flyktet</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatFort" translate="yes" xml:space="preserve">
           <source>Defeat Fort</source>
-          <target state="new">Defeat Fort</target>
+          <target state="needs-review-translation">Defeat Fort</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityEvolvePokemon" translate="yes" xml:space="preserve">
           <source>Evolve a Pokémon</source>
-          <target state="translated">Utvikle en Pokémon</target>
+          <target state="needs-review-translation">Utvikle en Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEgg" translate="yes" xml:space="preserve">
           <source>Egg Hatched!</source>
-          <target state="translated">Egg klekket!</target>
+          <target state="final">Egg klekket!</target>
         </trans-unit>
         <trans-unit id="ActivityWalkKm" translate="yes" xml:space="preserve">
           <source>Walk Km</source>
-          <target state="translated">Gå km</target>
+          <target state="final">Gå km</target>
         </trans-unit>
         <trans-unit id="ActivityPokedexEntryNew" translate="yes" xml:space="preserve">
           <source>New Pokémon</source>
-          <target state="translated">Ny Pokémon</target>
+          <target state="final">Ny Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityCatchFirstThrow" translate="yes" xml:space="preserve">
           <source>First Throw</source>
-          <target state="translated">Første Kast</target>
+          <target state="final">Første Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchNiceThrow" translate="yes" xml:space="preserve">
           <source>Nice Throw</source>
-          <target state="translated">Greit Kast</target>
+          <target state="final">Greit Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchGreatThrow" translate="yes" xml:space="preserve">
           <source>Great Throw</source>
-          <target state="translated">Nydelig Kast</target>
+          <target state="final">Nydelig Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchExcellentThrow" translate="yes" xml:space="preserve">
           <source>Excellent Throw</source>
-          <target state="translated">Perfekt Kast</target>
+          <target state="final">Perfekt Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchCurveball" translate="yes" xml:space="preserve">
           <source>Curveball</source>
-          <target state="translated">Kurvet kast</target>
+          <target state="final">Kurvet kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchFirstCatchOfDay" translate="yes" xml:space="preserve">
           <source>First Catch of Day!</source>
-          <target state="translated">Dagens Første Fangst!</target>
+          <target state="final">Dagens Første Fangst!</target>
         </trans-unit>
         <trans-unit id="ActivityCatchMilestone" translate="yes" xml:space="preserve">
           <source>Catch Milestone</source>
-          <target state="translated">Fang Milestone</target>
+          <target state="needs-review-translation">Fang Milestone</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityTrainPokemon" translate="yes" xml:space="preserve">
           <source>Train Pokémon</source>
-          <target state="translated">Tren Pokémon</target>
+          <target state="final">Tren Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivitySearchFort" translate="yes" xml:space="preserve">
           <source>Search Fort</source>
-          <target state="new">Search Fort</target>
+          <target state="needs-review-translation">Search Fort</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityReleasePokemon" translate="yes" xml:space="preserve">
           <source>Release Pokémon</source>
-          <target state="translated">Slipp Pokémon Løs</target>
+          <target state="final">Slipp Pokémon Løs</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggSmallBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Small Bonus</source>
-          <target state="translated">Bonus For Lite Egg Klekket</target>
+          <target state="final">Bonus For Lite Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggMediumBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Medium Bonus</source>
-          <target state="translated">Bonus For Mellomstort Egg Klekket</target>
+          <target state="final">Bonus For Mellomstort Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggLargeBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Large Bonus</source>
-          <target state="translated">Bonus For Stort Egg Klekket</target>
+          <target state="final">Bonus For Stort Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatGymDefender" translate="yes" xml:space="preserve">
           <source>Defeat Gym Defender</source>
-          <target state="translated">Slå Pokégym Forsvareren</target>
+          <target state="needs-review-translation">Slå Pokégym Forsvareren</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatGymLeader" translate="yes" xml:space="preserve">
           <source>Defeat Gym Leader</source>
-          <target state="translated">Slå Pokégym Lederen</target>
+          <target state="needs-review-translation">Slå Pokégym Lederen</target>
         </trans-unit>
         <trans-unit id="Combat" translate="yes" xml:space="preserve">
           <source>Combat</source>
-          <target state="translated">Kamp</target>
+          <target state="final">Styrke</target>
         </trans-unit>
         <trans-unit id="Date" translate="yes" xml:space="preserve">
           <source>Date</source>
-          <target state="translated">Dato</target>
+          <target state="final">Dato</target>
         </trans-unit>
         <trans-unit id="Fav" translate="yes" xml:space="preserve">
           <source>Favorite</source>
-          <target state="translated">Favoritt</target>
+          <target state="final">Favoritt</target>
         </trans-unit>
         <trans-unit id="Health" translate="yes" xml:space="preserve">
           <source>Health</source>
-          <target state="translated">Helse</target>
+          <target state="final">HP</target>
         </trans-unit>
         <trans-unit id="Name" translate="yes" xml:space="preserve">
           <source>Name</source>
-          <target state="translated">Navn</target>
+          <target state="final">Navn</target>
         </trans-unit>
         <trans-unit id="Number" translate="yes" xml:space="preserve">
           <source>Number</source>
-          <target state="translated">Nummer</target>
+          <target state="final">Nummer</target>
         </trans-unit>
         <trans-unit id="PokemonInventoryFullText" translate="yes" xml:space="preserve">
           <source>Your Pokémon inventory is full, transfer some Pokémon before trying to catch {0}.</source>
-          <target state="translated">Ditt Pokélager er fullt, overfør noen Pokémon før du prøver å fange {0}.</target>
+          <target state="final">Ditt Pokélager er fullt, overfør noen Pokémon før du prøver å fange {0}.</target>
         </trans-unit>
         <trans-unit id="WaitingForNetworkText" translate="yes" xml:space="preserve">
           <source>Waiting for network to be back...</source>
-          <target state="translated">Venter på at nettverket kommer tilbake...</target>
+          <target state="final">Venter på at nettverket kommer tilbake...</target>
         </trans-unit>
         <trans-unit id="EggHatchMessage" translate="yes" xml:space="preserve">
           <source>An Egg hatched into a {0}.
 You also got {1} Stardust, {2} Candy and {3} XP.</source>
-          <target state="translated">Et Egg ble klekket til en {0}.
+          <target state="final">Et Egg klekket ut en {0}.
 Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="EvolvePokemonWarningText" translate="yes" xml:space="preserve">
           <source>Do you want to evolve {0}?</source>
-          <target state="translated">Vil du utvikle {0}?</target>
+          <target state="final">Vil du utvikle {0}?</target>
         </trans-unit>
         <trans-unit id="PowerUpPokemonWarningText" translate="yes" xml:space="preserve">
           <source>Do you want to use a power up for {0}?</source>
-          <target state="translated">Vil du øke kraften til {0}?</target>
+          <target state="final">Vil du øke kraften til {0}?</target>
         </trans-unit>
         <trans-unit id="TransferPokemonWarningTitle" translate="yes" xml:space="preserve">
           <source>Do you really want to transfer {0} to the Professor?</source>
-          <target state="translated">Vil du virkelig overføre {0} til Professoren?</target>
+          <target state="final">Vil du virkelig overføre {0} til Professoren?</target>
         </trans-unit>
         <trans-unit id="CancelText" translate="yes" xml:space="preserve">
           <source>CANCEL</source>
-          <target state="new">CANCEL</target>
+          <target state="final">AVBRYT</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="ItemDiscardWarningText" translate="yes" xml:space="preserve">
           <source>Discard {0}?</source>
-          <target state="new">Discard {0}?</target>
+          <target state="needs-review-translation">Kaste {0}?</target>
         </trans-unit>
         <trans-unit id="SetNickName" translate="yes" xml:space="preserve">
           <source>Set Nickname</source>
-          <target state="new">Set Nickname</target>
+          <target state="final">Angi Kallenavn</target>
         </trans-unit>
         <trans-unit id="OkText" translate="yes" xml:space="preserve">
           <source>O. K.</source>
-          <target state="new">O. K.</target>
+          <target state="needs-review-translation">O. K.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Space between . and K</note>
         </trans-unit>
         <trans-unit id="PokemonEncounterErrorText" translate="yes" xml:space="preserve">
@@ -2455,607 +2453,607 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
       <group id="POKEMONGO-UWP/STRINGS/EN-US/POKEDEX.RESW" datatype="resx">
         <trans-unit id="Bulbasaur.Description" translate="yes" xml:space="preserve">
           <source>Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun’s rays, the seed grows progressively larger.</source>
-          <target state="translated">Bulbasaur kan ses slappe av i sterkt sollys. Den har et frø på ryggen. Ved å absorbere solstråler kan frøet vokse større.</target>
+          <target state="final">Bulbasaur kan bli observert slappe av i sterkt sollys. Den har et frø på ryggen. Ved å absorbere solstråler kan frøet vokse større.</target>
         </trans-unit>
         <trans-unit id="Ivysaur.Description" translate="yes" xml:space="preserve">
           <source>There is a bud on this Pokémon’s back. To support its weight, Ivysaur’s legs and trunk grow thick and strong. If it starts spending more time lying in the sunlight, it’s a sign that the bud will bloom into a large flower soon.</source>
-          <target state="translated">Det er en spire på ryggen til denne Pokémonen. For å støtte vekten sin har Ivysaur sterke føtter og en tykk stilk som bærer spiren. Hvis Pokémonen bruker ekstra mye tid i solen er det et tegn på at spiren snart vil blomstre i en stor blomst.</target>
+          <target state="final">Det er en spire på ryggen til denne Pokémonen. For å støtte vekten sin har Ivysaur sterke føtter og en tykk stilk som bærer spiren. Hvis Pokémonen bruker ekstra mye tid i solen er det et tegn på at spiren snart vil blomstre i en stor blomst.</target>
         </trans-unit>
         <trans-unit id="Venusaur.Description" translate="yes" xml:space="preserve">
           <source>There is a large flower on Venusaur’s back. The flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower’s aroma soothes the emotions of people.</source>
-          <target state="translated">Det er en stor blomst på Venusaur sin rygg. Det sies at blomsten får levende og stærke farger hvis det får rikelig med ernæring og sollys. Blomstens aroma kan roe ned folks følelser.</target>
+          <target state="final">Det er en stor blomst på Venusaur sin rygg. Det sies at blomsten får levende og stærke farger hvis det får rikelig med ernæring og sollys. Blomstens aroma kan roe ned folk sine følelser.</target>
         </trans-unit>
         <trans-unit id="Charmander.Description" translate="yes" xml:space="preserve">
           <source>The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</source>
-          <target state="new">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
+          <target state="needs-review-translation">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
         </trans-unit>
         <trans-unit id="Charmeleon.Description" translate="yes" xml:space="preserve">
           <source>Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</source>
-          <target state="new">Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</target>
+          <target state="needs-review-translation">Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</target>
         </trans-unit>
         <trans-unit id="Charizard.Description" translate="yes" xml:space="preserve">
           <source>Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</source>
-          <target state="new">Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</target>
+          <target state="needs-review-translation">Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</target>
         </trans-unit>
         <trans-unit id="Squirtle.Description" translate="yes" xml:space="preserve">
           <source>Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</source>
-          <target state="new">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
+          <target state="needs-review-translation">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
         </trans-unit>
         <trans-unit id="Wartortle.Description" translate="yes" xml:space="preserve">
           <source>Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</source>
-          <target state="new">Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</target>
+          <target state="needs-review-translation">Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</target>
         </trans-unit>
         <trans-unit id="Blastoise.Description" translate="yes" xml:space="preserve">
           <source>Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</source>
-          <target state="new">Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</target>
+          <target state="needs-review-translation">Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</target>
         </trans-unit>
         <trans-unit id="Caterpie.Description" translate="yes" xml:space="preserve">
           <source>Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</source>
-          <target state="new">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
+          <target state="needs-review-translation">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
         </trans-unit>
         <trans-unit id="Metapod.Description" translate="yes" xml:space="preserve">
           <source>The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</source>
-          <target state="new">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
+          <target state="needs-review-translation">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
         </trans-unit>
         <trans-unit id="Butterfree.Description" translate="yes" xml:space="preserve">
           <source>Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</source>
-          <target state="new">Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</target>
+          <target state="needs-review-translation">Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</target>
         </trans-unit>
         <trans-unit id="Weedle.Description" translate="yes" xml:space="preserve">
           <source>Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</source>
-          <target state="new">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
+          <target state="needs-review-translation">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
         </trans-unit>
         <trans-unit id="Kakuna.Description" translate="yes" xml:space="preserve">
           <source>Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</source>
-          <target state="new">Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</target>
+          <target state="needs-review-translation">Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</target>
         </trans-unit>
         <trans-unit id="Beedrill.Description" translate="yes" xml:space="preserve">
           <source>Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</source>
-          <target state="new">Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</target>
+          <target state="needs-review-translation">Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</target>
         </trans-unit>
         <trans-unit id="Pidgey.Description" translate="yes" xml:space="preserve">
           <source>Pidgey has an extremely sharp sense of direction. It is capable of unerringly returning home to its nest, however far it may be removed from its familiar surroundings.</source>
-          <target state="new">Pidgey has an extremely sharp sense of direction. It is capable of unerringly returning home to its nest, however far it may be removed from its familiar surroundings.</target>
+          <target state="final">Pidgey har en svært god retningssans. Den kan alltid huske veien hjem til reiret, uansett hvor langt unna den er.</target>
         </trans-unit>
         <trans-unit id="Pidgeotto.Description" translate="yes" xml:space="preserve">
           <source>Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</source>
-          <target state="new">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
+          <target state="needs-review-translation">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
         </trans-unit>
         <trans-unit id="Pidgeot.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</source>
-          <target state="new">This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</target>
+          <target state="needs-review-translation">This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</target>
         </trans-unit>
         <trans-unit id="Rattata.Description" translate="yes" xml:space="preserve">
           <source>Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</source>
-          <target state="new">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
+          <target state="needs-review-translation">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
         </trans-unit>
         <trans-unit id="Raticate.Description" translate="yes" xml:space="preserve">
           <source>Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</source>
-          <target state="new">Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</target>
+          <target state="needs-review-translation">Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</target>
         </trans-unit>
         <trans-unit id="Spearow.Description" translate="yes" xml:space="preserve">
           <source>Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</source>
-          <target state="new">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
+          <target state="needs-review-translation">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
         </trans-unit>
         <trans-unit id="Fearow.Description" translate="yes" xml:space="preserve">
           <source>Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</source>
-          <target state="new">Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</target>
+          <target state="needs-review-translation">Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</target>
         </trans-unit>
         <trans-unit id="Ekans.Description" translate="yes" xml:space="preserve">
           <source>Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</source>
-          <target state="new">Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</target>
+          <target state="needs-review-translation">Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</target>
         </trans-unit>
         <trans-unit id="Arbok.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</source>
-          <target state="new">This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</target>
+          <target state="needs-review-translation">This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</target>
         </trans-unit>
         <trans-unit id="Pikachu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</source>
-          <target state="new">This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</target>
+          <target state="needs-review-translation">This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</target>
         </trans-unit>
         <trans-unit id="Raichu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</source>
-          <target state="new">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
+          <target state="translated">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
         </trans-unit>
         <trans-unit id="Sandshrew.Description" translate="yes" xml:space="preserve">
           <source>Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</source>
-          <target state="new">Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</target>
+          <target state="needs-review-translation">Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</target>
         </trans-unit>
         <trans-unit id="Sandslash.Description" translate="yes" xml:space="preserve">
           <source>Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</source>
-          <target state="new">Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</target>
+          <target state="needs-review-translation">Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</target>
         </trans-unit>
         <trans-unit id="NidoranFemale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</source>
-          <target state="new">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
+          <target state="needs-review-translation">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
         </trans-unit>
         <trans-unit id="Nidorina.Description" translate="yes" xml:space="preserve">
           <source>When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</source>
-          <target state="new">When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</target>
+          <target state="needs-review-translation">When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</target>
         </trans-unit>
         <trans-unit id="Nidoqueen.Description" translate="yes" xml:space="preserve">
           <source>Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</source>
-          <target state="new">Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</target>
+          <target state="needs-review-translation">Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</target>
         </trans-unit>
         <trans-unit id="NidoranMale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</source>
-          <target state="new">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
+          <target state="needs-review-translation">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
         </trans-unit>
         <trans-unit id="Nidorino.Description" translate="yes" xml:space="preserve">
           <source>Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</source>
-          <target state="new">Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</target>
+          <target state="needs-review-translation">Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</target>
         </trans-unit>
         <trans-unit id="Nidoking.Description" translate="yes" xml:space="preserve">
           <source>Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</source>
-          <target state="new">Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</target>
+          <target state="needs-review-translation">Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</target>
         </trans-unit>
         <trans-unit id="Clefairy.Description" translate="yes" xml:space="preserve">
           <source>On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</source>
-          <target state="new">On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</target>
+          <target state="needs-review-translation">On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</target>
         </trans-unit>
         <trans-unit id="Clefable.Description" translate="yes" xml:space="preserve">
           <source>Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</source>
-          <target state="new">Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</target>
+          <target state="needs-review-translation">Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="new">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
+          <target state="translated">Elektrisk-type</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>
-          <target state="new">Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</target>
+          <target state="needs-review-translation">Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</target>
         </trans-unit>
         <trans-unit id="Jigglypuff.Description" translate="yes" xml:space="preserve">
           <source>When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</source>
-          <target state="new">When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</target>
+          <target state="needs-review-translation">When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</target>
         </trans-unit>
         <trans-unit id="Wigglytuff.Description" translate="yes" xml:space="preserve">
           <source>Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</source>
-          <target state="new">Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</target>
+          <target state="needs-review-translation">Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</target>
         </trans-unit>
         <trans-unit id="Zubat.Description" translate="yes" xml:space="preserve">
           <source>Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</source>
-          <target state="new">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
+          <target state="needs-review-translation">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
         </trans-unit>
         <trans-unit id="Golbat.Description" translate="yes" xml:space="preserve">
           <source>Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</source>
-          <target state="new">Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</target>
+          <target state="needs-review-translation">Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</target>
         </trans-unit>
         <trans-unit id="Oddish.Description" translate="yes" xml:space="preserve">
           <source>Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</source>
-          <target state="new">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
+          <target state="needs-review-translation">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
         </trans-unit>
         <trans-unit id="Gloom.Description" translate="yes" xml:space="preserve">
           <source>From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</source>
-          <target state="new">From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</target>
+          <target state="needs-review-translation">From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</target>
         </trans-unit>
         <trans-unit id="Vileplume.Description" translate="yes" xml:space="preserve">
           <source>Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</source>
-          <target state="new">Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</target>
+          <target state="needs-review-translation">Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</target>
         </trans-unit>
         <trans-unit id="Paras.Description" translate="yes" xml:space="preserve">
           <source>Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</source>
-          <target state="new">Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</target>
+          <target state="needs-review-translation">Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</target>
         </trans-unit>
         <trans-unit id="Parasect.Description" translate="yes" xml:space="preserve">
           <source>Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</source>
-          <target state="new">Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</target>
+          <target state="needs-review-translation">Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</target>
         </trans-unit>
         <trans-unit id="Venonat.Description" translate="yes" xml:space="preserve">
           <source>Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</source>
-          <target state="new">Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</target>
+          <target state="needs-review-translation">Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</target>
         </trans-unit>
         <trans-unit id="Venomoth.Description" translate="yes" xml:space="preserve">
           <source>Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</source>
-          <target state="new">Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</target>
+          <target state="needs-review-translation">Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</target>
         </trans-unit>
         <trans-unit id="Diglett.Description" translate="yes" xml:space="preserve">
           <source>Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</source>
-          <target state="new">Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</target>
+          <target state="needs-review-translation">Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</target>
         </trans-unit>
         <trans-unit id="Dugtrio.Description" translate="yes" xml:space="preserve">
           <source>Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</source>
-          <target state="new">Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</target>
+          <target state="needs-review-translation">Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</target>
         </trans-unit>
         <trans-unit id="Meowth.Description" translate="yes" xml:space="preserve">
           <source>Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</source>
-          <target state="new">Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</target>
+          <target state="needs-review-translation">Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</target>
         </trans-unit>
         <trans-unit id="Persian.Description" translate="yes" xml:space="preserve">
           <source>Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</source>
-          <target state="new">Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</target>
+          <target state="needs-review-translation">Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</target>
         </trans-unit>
         <trans-unit id="Psyduck.Description" translate="yes" xml:space="preserve">
           <source>If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</source>
-          <target state="new">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
+          <target state="translated">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
         </trans-unit>
         <trans-unit id="Golduck.Description" translate="yes" xml:space="preserve">
           <source>Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</source>
-          <target state="new">Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</target>
+          <target state="needs-review-translation">Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</target>
         </trans-unit>
         <trans-unit id="Mankey.Description" translate="yes" xml:space="preserve">
           <source>When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</source>
-          <target state="new">When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</target>
+          <target state="needs-review-translation">When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</target>
         </trans-unit>
         <trans-unit id="Primeape.Description" translate="yes" xml:space="preserve">
           <source>When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</source>
-          <target state="new">When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</target>
+          <target state="needs-review-translation">When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</target>
         </trans-unit>
         <trans-unit id="Growlithe.Description" translate="yes" xml:space="preserve">
           <source>Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</source>
-          <target state="new">Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</target>
+          <target state="needs-review-translation">Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</target>
         </trans-unit>
         <trans-unit id="Arcanine.Description" translate="yes" xml:space="preserve">
           <source>Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</source>
-          <target state="new">Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</target>
+          <target state="needs-review-translation">Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</target>
         </trans-unit>
         <trans-unit id="Poliwag.Description" translate="yes" xml:space="preserve">
           <source>Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</source>
-          <target state="new">Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</target>
+          <target state="needs-review-translation">Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</target>
         </trans-unit>
         <trans-unit id="Poliwhirl.Description" translate="yes" xml:space="preserve">
           <source>The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</source>
-          <target state="new">The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</target>
+          <target state="needs-review-translation">The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</target>
         </trans-unit>
         <trans-unit id="Poliwrath.Description" translate="yes" xml:space="preserve">
           <source>Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</source>
-          <target state="new">Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</target>
+          <target state="needs-review-translation">Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</target>
         </trans-unit>
         <trans-unit id="Abra.Description" translate="yes" xml:space="preserve">
           <source>Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</source>
-          <target state="new">Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</target>
+          <target state="needs-review-translation">Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</target>
         </trans-unit>
         <trans-unit id="Kadabra.Description" translate="yes" xml:space="preserve">
           <source>Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</source>
-          <target state="new">Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</target>
+          <target state="needs-review-translation">Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</target>
         </trans-unit>
         <trans-unit id="Alakazam.Description" translate="yes" xml:space="preserve">
           <source>Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</source>
-          <target state="new">Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</target>
+          <target state="needs-review-translation">Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</target>
         </trans-unit>
         <trans-unit id="Machop.Description" translate="yes" xml:space="preserve">
           <source>Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</source>
-          <target state="new">Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</target>
+          <target state="needs-review-translation">Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</target>
         </trans-unit>
         <trans-unit id="Machoke.Description" translate="yes" xml:space="preserve">
           <source>Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</source>
-          <target state="new">Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</target>
+          <target state="needs-review-translation">Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</target>
         </trans-unit>
         <trans-unit id="Machamp.Description" translate="yes" xml:space="preserve">
           <source>Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</source>
-          <target state="new">Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</target>
+          <target state="needs-review-translation">Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</target>
         </trans-unit>
         <trans-unit id="Bellsprout.Description" translate="yes" xml:space="preserve">
           <source>Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</source>
-          <target state="new">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
+          <target state="needs-review-translation">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
         </trans-unit>
         <trans-unit id="Weepinbell.Description" translate="yes" xml:space="preserve">
           <source>Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</source>
-          <target state="new">Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</target>
+          <target state="needs-review-translation">Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</target>
         </trans-unit>
         <trans-unit id="Victreebel.Description" translate="yes" xml:space="preserve">
           <source>Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</source>
-          <target state="new">Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</target>
+          <target state="needs-review-translation">Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</target>
         </trans-unit>
         <trans-unit id="Tentacool.Description" translate="yes" xml:space="preserve">
           <source>Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</source>
-          <target state="new">Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</target>
+          <target state="needs-review-translation">Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</target>
         </trans-unit>
         <trans-unit id="Tentacruel.Description" translate="yes" xml:space="preserve">
           <source>Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</source>
-          <target state="new">Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</target>
+          <target state="needs-review-translation">Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</target>
         </trans-unit>
         <trans-unit id="Geodude.Description" translate="yes" xml:space="preserve">
           <source>When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</source>
-          <target state="new">When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</target>
+          <target state="needs-review-translation">When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</target>
         </trans-unit>
         <trans-unit id="Graveler.Description" translate="yes" xml:space="preserve">
           <source>Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</source>
-          <target state="new">Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</target>
+          <target state="needs-review-translation">Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</target>
         </trans-unit>
         <trans-unit id="Golem.Description" translate="yes" xml:space="preserve">
           <source>Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</source>
-          <target state="new">Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</target>
+          <target state="needs-review-translation">Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</target>
         </trans-unit>
         <trans-unit id="Ponyta.Description" translate="yes" xml:space="preserve">
           <source>Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</source>
-          <target state="new">Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</target>
+          <target state="needs-review-translation">Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</target>
         </trans-unit>
         <trans-unit id="Rapidash.Description" translate="yes" xml:space="preserve">
           <source>Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</source>
-          <target state="new">Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</target>
+          <target state="needs-review-translation">Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</target>
         </trans-unit>
         <trans-unit id="Slowpoke.Description" translate="yes" xml:space="preserve">
           <source>Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</source>
-          <target state="new">Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</target>
+          <target state="needs-review-translation">Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</target>
         </trans-unit>
         <trans-unit id="Slowbro.Description" translate="yes" xml:space="preserve">
           <source>Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</source>
-          <target state="new">Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</target>
+          <target state="needs-review-translation">Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</target>
         </trans-unit>
         <trans-unit id="Magnemite.Description" translate="yes" xml:space="preserve">
           <source>Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</source>
-          <target state="new">Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</target>
+          <target state="needs-review-translation">Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</target>
         </trans-unit>
         <trans-unit id="Magneton.Description" translate="yes" xml:space="preserve">
           <source>Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</source>
-          <target state="new">Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</target>
+          <target state="needs-review-translation">Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</target>
         </trans-unit>
         <trans-unit id="Farfetchd.Description" translate="yes" xml:space="preserve">
           <source>Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</source>
-          <target state="new">Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</target>
+          <target state="needs-review-translation">Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</target>
         </trans-unit>
         <trans-unit id="Doduo.Description" translate="yes" xml:space="preserve">
           <source>Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</source>
-          <target state="new">Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</target>
+          <target state="needs-review-translation">Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</target>
         </trans-unit>
         <trans-unit id="Dodrio.Description" translate="yes" xml:space="preserve">
           <source>Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</source>
-          <target state="new">Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</target>
+          <target state="needs-review-translation">Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</target>
         </trans-unit>
         <trans-unit id="Seel.Description" translate="yes" xml:space="preserve">
           <source>Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</source>
-          <target state="new">Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</target>
+          <target state="needs-review-translation">Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</target>
         </trans-unit>
         <trans-unit id="Dewgong.Description" translate="yes" xml:space="preserve">
           <source>Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</source>
-          <target state="new">Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</target>
+          <target state="needs-review-translation">Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</target>
         </trans-unit>
         <trans-unit id="Grimer.Description" translate="yes" xml:space="preserve">
           <source>Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</source>
-          <target state="new">Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</target>
+          <target state="needs-review-translation">Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</target>
         </trans-unit>
         <trans-unit id="Muk.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</source>
-          <target state="new">This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</target>
+          <target state="needs-review-translation">This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</target>
         </trans-unit>
         <trans-unit id="Shellder.Description" translate="yes" xml:space="preserve">
           <source>At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</source>
-          <target state="new">At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</target>
+          <target state="needs-review-translation">At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</target>
         </trans-unit>
         <trans-unit id="Cloyster.Description" translate="yes" xml:space="preserve">
           <source>Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</source>
-          <target state="new">Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</target>
+          <target state="needs-review-translation">Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</target>
         </trans-unit>
         <trans-unit id="Gastly.Description" translate="yes" xml:space="preserve">
           <source>Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</source>
-          <target state="new">Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</target>
+          <target state="needs-review-translation">Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</target>
         </trans-unit>
         <trans-unit id="Haunter.Description" translate="yes" xml:space="preserve">
           <source>Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</source>
-          <target state="new">Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</target>
+          <target state="needs-review-translation">Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</target>
         </trans-unit>
         <trans-unit id="Gengar.Description" translate="yes" xml:space="preserve">
           <source>Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</source>
-          <target state="new">Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</target>
+          <target state="needs-review-translation">Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</target>
         </trans-unit>
         <trans-unit id="Onix.Description" translate="yes" xml:space="preserve">
           <source>Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</source>
-          <target state="new">Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</target>
+          <target state="needs-review-translation">Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</target>
         </trans-unit>
         <trans-unit id="Drowzee.Description" translate="yes" xml:space="preserve">
           <source>If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</source>
-          <target state="new">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
+          <target state="needs-review-translation">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
         </trans-unit>
         <trans-unit id="Hypno.Description" translate="yes" xml:space="preserve">
           <source>Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</source>
-          <target state="new">Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</target>
+          <target state="needs-review-translation">Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</target>
         </trans-unit>
         <trans-unit id="Krabby.Description" translate="yes" xml:space="preserve">
           <source>Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</source>
-          <target state="new">Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</target>
+          <target state="needs-review-translation">Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</target>
         </trans-unit>
         <trans-unit id="Kingler.Description" translate="yes" xml:space="preserve">
           <source>Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</source>
-          <target state="new">Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</target>
+          <target state="needs-review-translation">Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</target>
         </trans-unit>
         <trans-unit id="Voltorb.Description" translate="yes" xml:space="preserve">
           <source>Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</source>
-          <target state="new">Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</target>
+          <target state="needs-review-translation">Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</target>
         </trans-unit>
         <trans-unit id="Electrode.Description" translate="yes" xml:space="preserve">
           <source>One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</source>
-          <target state="new">One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</target>
+          <target state="needs-review-translation">One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</target>
         </trans-unit>
         <trans-unit id="Exeggcute.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</source>
-          <target state="new">This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</target>
+          <target state="needs-review-translation">This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</target>
         </trans-unit>
         <trans-unit id="Exeggutor.Description" translate="yes" xml:space="preserve">
           <source>Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</source>
-          <target state="new">Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</target>
+          <target state="needs-review-translation">Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</target>
         </trans-unit>
         <trans-unit id="Cubone.Description" translate="yes" xml:space="preserve">
           <source>Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</source>
-          <target state="new">Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</target>
+          <target state="needs-review-translation">Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</target>
         </trans-unit>
         <trans-unit id="Marowak.Description" translate="yes" xml:space="preserve">
           <source>Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</source>
-          <target state="new">Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</target>
+          <target state="needs-review-translation">Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</target>
         </trans-unit>
         <trans-unit id="Hitmonlee.Description" translate="yes" xml:space="preserve">
           <source>Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</source>
-          <target state="new">Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</target>
+          <target state="needs-review-translation">Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</target>
         </trans-unit>
         <trans-unit id="Hitmonchan.Description" translate="yes" xml:space="preserve">
           <source>Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</source>
-          <target state="new">Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</target>
+          <target state="needs-review-translation">Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</target>
         </trans-unit>
         <trans-unit id="Lickitung.Description" translate="yes" xml:space="preserve">
           <source>Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</source>
-          <target state="new">Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</target>
+          <target state="needs-review-translation">Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</target>
         </trans-unit>
         <trans-unit id="Koffing.Description" translate="yes" xml:space="preserve">
           <source>Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</source>
-          <target state="new">Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</target>
+          <target state="needs-review-translation">Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</target>
         </trans-unit>
         <trans-unit id="Weezing.Description" translate="yes" xml:space="preserve">
           <source>Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</source>
-          <target state="new">Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</target>
+          <target state="needs-review-translation">Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</target>
         </trans-unit>
         <trans-unit id="Rhyhorn.Description" translate="yes" xml:space="preserve">
           <source>Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</source>
-          <target state="new">Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</target>
+          <target state="needs-review-translation">Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</target>
         </trans-unit>
         <trans-unit id="Rhydon.Description" translate="yes" xml:space="preserve">
           <source>Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</source>
-          <target state="new">Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</target>
+          <target state="needs-review-translation">Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</target>
         </trans-unit>
         <trans-unit id="Chansey.Description" translate="yes" xml:space="preserve">
           <source>Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</source>
-          <target state="new">Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</target>
+          <target state="needs-review-translation">Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</target>
         </trans-unit>
         <trans-unit id="Tangela.Description" translate="yes" xml:space="preserve">
           <source>Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</source>
-          <target state="new">Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</target>
+          <target state="needs-review-translation">Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</target>
         </trans-unit>
         <trans-unit id="Kangaskhan.Description" translate="yes" xml:space="preserve">
           <source>If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</source>
-          <target state="new">If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</target>
+          <target state="needs-review-translation">If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</target>
         </trans-unit>
         <trans-unit id="Horsea.Description" translate="yes" xml:space="preserve">
           <source>If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</source>
-          <target state="new">If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</target>
+          <target state="needs-review-translation">If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</target>
         </trans-unit>
         <trans-unit id="Seadra.Description" translate="yes" xml:space="preserve">
           <source>Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</source>
-          <target state="new">Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</target>
+          <target state="needs-review-translation">Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</target>
         </trans-unit>
         <trans-unit id="Goldeen.Description" translate="yes" xml:space="preserve">
           <source>Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</source>
-          <target state="new">Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</target>
+          <target state="needs-review-translation">Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</target>
         </trans-unit>
         <trans-unit id="Seaking.Description" translate="yes" xml:space="preserve">
           <source>Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</source>
-          <target state="new">Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</target>
+          <target state="needs-review-translation">Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</target>
         </trans-unit>
         <trans-unit id="Staryu.Description" translate="yes" xml:space="preserve">
           <source>Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</source>
-          <target state="new">Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</target>
+          <target state="needs-review-translation">Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</target>
         </trans-unit>
         <trans-unit id="Starmie.Description" translate="yes" xml:space="preserve">
           <source>Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</source>
-          <target state="new">Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</target>
+          <target state="needs-review-translation">Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</target>
         </trans-unit>
         <trans-unit id="MrMime.Description" translate="yes" xml:space="preserve">
           <source>Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</source>
-          <target state="new">Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</target>
+          <target state="needs-review-translation">Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</target>
         </trans-unit>
         <trans-unit id="Scyther.Description" translate="yes" xml:space="preserve">
           <source>Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</source>
-          <target state="new">Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</target>
+          <target state="needs-review-translation">Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</target>
         </trans-unit>
         <trans-unit id="Jynx.Description" translate="yes" xml:space="preserve">
           <source>Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</source>
-          <target state="new">Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</target>
+          <target state="needs-review-translation">Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</target>
         </trans-unit>
         <trans-unit id="Electabuzz.Description" translate="yes" xml:space="preserve">
           <source>When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</source>
-          <target state="new">When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</target>
+          <target state="needs-review-translation">When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</target>
         </trans-unit>
         <trans-unit id="Magmar.Description" translate="yes" xml:space="preserve">
           <source>In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</source>
-          <target state="new">In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</target>
+          <target state="needs-review-translation">In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</target>
         </trans-unit>
         <trans-unit id="Pinsir.Description" translate="yes" xml:space="preserve">
           <source>Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</source>
-          <target state="new">Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</target>
+          <target state="needs-review-translation">Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</target>
         </trans-unit>
         <trans-unit id="Tauros.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</source>
-          <target state="new">This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</target>
+          <target state="needs-review-translation">This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</target>
         </trans-unit>
         <trans-unit id="Magikarp.Description" translate="yes" xml:space="preserve">
           <source>Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</source>
-          <target state="new">Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</target>
+          <target state="needs-review-translation">Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</target>
         </trans-unit>
         <trans-unit id="Gyarados.Description" translate="yes" xml:space="preserve">
           <source>Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</source>
-          <target state="new">Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</target>
+          <target state="needs-review-translation">Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</target>
         </trans-unit>
         <trans-unit id="Lapras.Description" translate="yes" xml:space="preserve">
           <source>People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</source>
-          <target state="new">People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</target>
+          <target state="needs-review-translation">People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</target>
         </trans-unit>
         <trans-unit id="Ditto.Description" translate="yes" xml:space="preserve">
           <source>Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</source>
-          <target state="new">Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</target>
+          <target state="needs-review-translation">Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</target>
         </trans-unit>
         <trans-unit id="Eevee.Description" translate="yes" xml:space="preserve">
           <source>Eevee has an unstable genetic makeup that suddenly mutates due to the environment in which it lives. Radiation from various stones causes this Pokémon to evolve.</source>
-          <target state="new">Eevee has an unstable genetic makeup that suddenly mutates due to the environment in which it lives. Radiation from various stones causes this Pokémon to evolve.</target>
+          <target state="final">Eevee har svært ustabile gener som gjør at den kan muteres. Mutasjonen kommer ann på miljøet den lever i. Stråling fra ulike steiner kan føre denne Pokémonen til å utvikle seg.</target>
         </trans-unit>
         <trans-unit id="Vaporeon.Description" translate="yes" xml:space="preserve">
           <source>Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</source>
-          <target state="new">Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</target>
+          <target state="needs-review-translation">Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</target>
         </trans-unit>
         <trans-unit id="Jolteon.Description" translate="yes" xml:space="preserve">
           <source>Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</source>
-          <target state="new">Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</target>
+          <target state="needs-review-translation">Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</target>
         </trans-unit>
         <trans-unit id="Flareon.Description" translate="yes" xml:space="preserve">
           <source>Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</source>
-          <target state="new">Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</target>
+          <target state="needs-review-translation">Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</target>
         </trans-unit>
         <trans-unit id="Porygon.Description" translate="yes" xml:space="preserve">
           <source>Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</source>
-          <target state="new">Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</target>
+          <target state="needs-review-translation">Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</target>
         </trans-unit>
         <trans-unit id="Omanyte.Description" translate="yes" xml:space="preserve">
           <source>Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</source>
-          <target state="new">Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</target>
+          <target state="needs-review-translation">Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</target>
         </trans-unit>
         <trans-unit id="Omastar.Description" translate="yes" xml:space="preserve">
           <source>Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</source>
-          <target state="new">Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</target>
+          <target state="needs-review-translation">Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</target>
         </trans-unit>
         <trans-unit id="Kabuto.Description" translate="yes" xml:space="preserve">
           <source>Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</source>
-          <target state="new">Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</target>
+          <target state="needs-review-translation">Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</target>
         </trans-unit>
         <trans-unit id="Kabutops.Description" translate="yes" xml:space="preserve">
           <source>Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</source>
-          <target state="new">Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</target>
+          <target state="needs-review-translation">Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</target>
         </trans-unit>
         <trans-unit id="Aerodactyl.Description" translate="yes" xml:space="preserve">
           <source>Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</source>
-          <target state="new">Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</target>
+          <target state="needs-review-translation">Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</target>
         </trans-unit>
         <trans-unit id="Snorlax.Description" translate="yes" xml:space="preserve">
           <source>Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</source>
-          <target state="new">Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</target>
+          <target state="needs-review-translation">Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</target>
         </trans-unit>
         <trans-unit id="Articuno.Description" translate="yes" xml:space="preserve">
           <source>Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</source>
-          <target state="new">Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</target>
+          <target state="needs-review-translation">Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</target>
         </trans-unit>
         <trans-unit id="Zapdos.Description" translate="yes" xml:space="preserve">
           <source>Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</source>
-          <target state="new">Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</target>
+          <target state="needs-review-translation">Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</target>
         </trans-unit>
         <trans-unit id="Moltres.Description" translate="yes" xml:space="preserve">
           <source>Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</source>
-          <target state="new">Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</target>
+          <target state="needs-review-translation">Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</target>
         </trans-unit>
         <trans-unit id="Dratini.Description" translate="yes" xml:space="preserve">
           <source>Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</source>
-          <target state="new">Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</target>
+          <target state="needs-review-translation">Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</target>
         </trans-unit>
         <trans-unit id="Dragonair.Description" translate="yes" xml:space="preserve">
           <source>Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</source>
-          <target state="new">Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</target>
+          <target state="needs-review-translation">Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</target>
         </trans-unit>
         <trans-unit id="Dragonite.Description" translate="yes" xml:space="preserve">
           <source>Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</source>
-          <target state="new">Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</target>
+          <target state="needs-review-translation">Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</target>
         </trans-unit>
         <trans-unit id="Mewtwo.Description" translate="yes" xml:space="preserve">
           <source>Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</source>
-          <target state="new">Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</target>
+          <target state="needs-review-translation">Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</target>
         </trans-unit>
         <trans-unit id="Mew.Description" translate="yes" xml:space="preserve">
           <source>Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</source>
-          <target state="new">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
+          <target state="translated">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
         </trans-unit>
       </group>
     </body>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
@@ -390,7 +390,7 @@
         </trans-unit>
         <trans-unit id="NumberTextBlock.Text" translate="yes" xml:space="preserve">
           <source>+ </source>
-          <target state="needs-review-translation"># </target>
+          <target state="needs-review-translation">+ </target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
           <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the +</note>
         </trans-unit>
@@ -1090,11 +1090,11 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="PokemonEncounterErrorText" translate="yes" xml:space="preserve">
           <source>There was an error loading the encounter with {0}, please try again later.</source>
-          <target state="new">There was an error loading the encounter with {0}, please try again later.</target>
+          <target state="new">Det oppstod en feil under lasting av møtet med {0}, prøv igjen senere.</target>
         </trans-unit>
         <trans-unit id="PokemonEncounterNotInRangeText" translate="yes" xml:space="preserve">
           <source>{0} is not in catch range anymore.</source>
-          <target state="new">{0} is not in catch range anymore.</target>
+          <target state="new">{0} er ikke i område lenger.</target>
         </trans-unit>
       </group>
     </body>
@@ -2597,7 +2597,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="translated">Elektrisk-type</target>
+          <target state="translated">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nb-NO.xlf
@@ -1096,6 +1096,10 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
           <source>{0} is not in catch range anymore.</source>
           <target state="new">{0} er ikke i område lenger.</target>
         </trans-unit>
+        <trans-unit id="CannotTransferFavorite" translate="yes" xml:space="preserve">
+          <source>Cannot transfer a favorite Pokémon!</source>
+          <target state="new">Du kan ikke overføre en favoritt Pokémon!</target>
+        </trans-unit>
       </group>
     </body>
   </file>
@@ -2465,7 +2469,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Charmander.Description" translate="yes" xml:space="preserve">
           <source>The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</source>
-          <target state="needs-review-translation">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
+          <target state="final">Flammen som brenner på tuppen av halen er en indikasjon på Pokémonen sine følelser. Flammen lager bølger når Charmander koser seg. Hvis Pokémonen blir rasende brenner flammen voldsomt.</target>
         </trans-unit>
         <trans-unit id="Charmeleon.Description" translate="yes" xml:space="preserve">
           <source>Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</source>
@@ -2477,7 +2481,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Squirtle.Description" translate="yes" xml:space="preserve">
           <source>Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</source>
-          <target state="needs-review-translation">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
+          <target state="final">Squirtle sitt skall er ikke bare brukt for beskyttelse. Skallet har en avrundet form og riller på overflaten som reduserer motstand i vann, slik at Pokémonen kan svømme i høye hastigheter.</target>
         </trans-unit>
         <trans-unit id="Wartortle.Description" translate="yes" xml:space="preserve">
           <source>Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</source>
@@ -2489,11 +2493,11 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Caterpie.Description" translate="yes" xml:space="preserve">
           <source>Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</source>
-          <target state="needs-review-translation">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
+          <target state="final">Caterpie har en glupsk appetitt. Den kan sluke blader større enn kroppen sin rett foran øynene dine. Fra antenene sender den ut en forferdelig sterk lukt. </target>
         </trans-unit>
         <trans-unit id="Metapod.Description" translate="yes" xml:space="preserve">
           <source>The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</source>
-          <target state="needs-review-translation">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
+          <target state="final">Skallet som dekker Pokémonen sin kropp er like hard som jern. Metapod flytte ikke mye. Det ligger stille fordi det forbereder utviklingen sin innenfor det harde skallet.</target>
         </trans-unit>
         <trans-unit id="Butterfree.Description" translate="yes" xml:space="preserve">
           <source>Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</source>
@@ -2501,7 +2505,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Weedle.Description" translate="yes" xml:space="preserve">
           <source>Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</source>
-          <target state="needs-review-translation">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
+          <target state="final">Weedle har en ekstremt skarp luktesans. Den er i stand til å skille ut sine favoritt blader fra de den misliker ved sniffing med sin store røde nese.</target>
         </trans-unit>
         <trans-unit id="Kakuna.Description" translate="yes" xml:space="preserve">
           <source>Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</source>
@@ -2517,7 +2521,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Pidgeotto.Description" translate="yes" xml:space="preserve">
           <source>Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</source>
-          <target state="needs-review-translation">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
+          <target state="final">Pidgeotto tar store områder og lager det til sitt eget territorium. Den flyr rundt og patruljerer sitt territorium. Hvis territoriumet blir forstyrret, viser den ingen nåde og vil grundig straffe fienden med sine skarpe klør.</target>
         </trans-unit>
         <trans-unit id="Pidgeot.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</source>
@@ -2525,7 +2529,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Rattata.Description" translate="yes" xml:space="preserve">
           <source>Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</source>
-          <target state="needs-review-translation">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
+          <target state="final">Rattata er svært forsiktig. Selv når den hviler, lytter den stadig etter lyder ved å bevege ørene. Den er ikke kresen om hvor den bor. Den lager reir overalt!</target>
         </trans-unit>
         <trans-unit id="Raticate.Description" translate="yes" xml:space="preserve">
           <source>Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</source>
@@ -2533,7 +2537,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Spearow.Description" translate="yes" xml:space="preserve">
           <source>Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</source>
-          <target state="needs-review-translation">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
+          <target state="final">Spearow har et svært høyt rop som kan høres over en kilometer unna. Hvis du hører mange av ropene i et ekko, er det et tegn på at de advarer hverandre for potensiell fare.</target>
         </trans-unit>
         <trans-unit id="Fearow.Description" translate="yes" xml:space="preserve">
           <source>Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</source>
@@ -2553,7 +2557,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Raichu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</source>
-          <target state="translated">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
+          <target state="final">Denne Pokémonen utstråler en svak elektrisk ladning fra kroppen. Dette gjør at den har en svak glød i mørke. Raichu kan sette halen i bakken for å slippe ut elektrisitet.</target>
         </trans-unit>
         <trans-unit id="Sandshrew.Description" translate="yes" xml:space="preserve">
           <source>Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</source>
@@ -2565,7 +2569,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranFemale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</source>
-          <target state="needs-review-translation">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
+          <target state="final">Nidoran♀ har pigger med mothaker som sender ut en kraftig gift. Piggene er antatt å ha utviklet seg som beskyttelse for denne lille Pokémonen. Når den blir rasende sender den ut en fryktelig toksin fra hornene.</target>
         </trans-unit>
         <trans-unit id="Nidorina.Description" translate="yes" xml:space="preserve">
           <source>When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</source>
@@ -2577,7 +2581,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranMale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</source>
-          <target state="needs-review-translation">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
+          <target state="final">Nidoran♂ har utviklet muskler for å flytte ørene rundt omkring. Takket være dem, kan ørene fritt flyttes i alle retninger. Selv den minste lyd, kan ikke unnslippe å bli hørt av ørene.</target>
         </trans-unit>
         <trans-unit id="Nidorino.Description" translate="yes" xml:space="preserve">
           <source>Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</source>
@@ -2597,7 +2601,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="translated">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
+          <target state="final">Inne i Vulpixs sin kropp, brenner en flamme som aldri går ut. På dagtid, når temperaturen stiger, sender Pokémonen ut flammer fra munnen for å hindre at kroppen blir for varmt.</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>
@@ -2613,7 +2617,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Zubat.Description" translate="yes" xml:space="preserve">
           <source>Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</source>
-          <target state="needs-review-translation">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
+          <target state="final">Zubat unngår sollys fordi eksponering fører at den blir dårlig. På dagtid oppholder den deg i huler eller under tak i gamle hus. Den sover hengende opp ned.</target>
         </trans-unit>
         <trans-unit id="Golbat.Description" translate="yes" xml:space="preserve">
           <source>Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</source>
@@ -2621,7 +2625,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Oddish.Description" translate="yes" xml:space="preserve">
           <source>Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</source>
-          <target state="needs-review-translation">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
+          <target state="final">Oddish søker etter fruktbar, næringsrik jord, der den kan plante seg selv. På dagtid, mens den er plantet, er Pokémonen sine føtter antatt å endre form til røtter.</target>
         </trans-unit>
         <trans-unit id="Gloom.Description" translate="yes" xml:space="preserve">
           <source>From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</source>
@@ -2665,7 +2669,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Psyduck.Description" translate="yes" xml:space="preserve">
           <source>If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</source>
-          <target state="translated">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
+          <target state="final">Hvis den bruker sin mystiske kraft, kan ikke Psyduck huske at den har brukt den. Den klarer ikke forme et minne av en slik hendelse fordi den går inn i en meditativ tilstand. Denne tilstanden er ganske lik dyp søvn.</target>
         </trans-unit>
         <trans-unit id="Golduck.Description" translate="yes" xml:space="preserve">
           <source>Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</source>
@@ -2725,7 +2729,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Bellsprout.Description" translate="yes" xml:space="preserve">
           <source>Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</source>
-          <target state="needs-review-translation">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
+          <target state="final">Bellsprout har en tynn og fleksibel kropp som lar den svinge og svaie seg for å unngå alle angrep. Den må ikke bli undervurdert. Fra munnen spytter den en korroderende væske som til og med kan smelte jern.</target>
         </trans-unit>
         <trans-unit id="Weepinbell.Description" translate="yes" xml:space="preserve">
           <source>Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</source>
@@ -2833,7 +2837,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Drowzee.Description" translate="yes" xml:space="preserve">
           <source>If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</source>
-          <target state="needs-review-translation">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
+          <target state="final">Hvis nesen din blir kløende mens du sover, er det et sikkert tegn på at en av denne Pokémonen står ovenfor sengen din for å prøve å ta drømmene dine.</target>
         </trans-unit>
         <trans-unit id="Hypno.Description" translate="yes" xml:space="preserve">
           <source>Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</source>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
@@ -391,7 +391,6 @@
         <trans-unit id="NumberTextBlock.Text" translate="yes" xml:space="preserve">
           <source>+ </source>
           <target state="needs-review-translation">+ </target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
           <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the +</note>
         </trans-unit>
         <trans-unit id="SlashSpaceCpTextBlock.Text" translate="yes" xml:space="preserve">
@@ -2465,7 +2464,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Charmander.Description" translate="yes" xml:space="preserve">
           <source>The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</source>
-          <target state="needs-review-translation">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
+          <target state="translated">Flammen som brenner på tuppen av halen er en indikasjon på Pokémonen sine følelser. Flammen lager bølger når Charmander koser seg. Hvis Pokémonen blir rasende brenner flammen voldsomt.</target>
         </trans-unit>
         <trans-unit id="Charmeleon.Description" translate="yes" xml:space="preserve">
           <source>Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</source>
@@ -2477,7 +2476,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Squirtle.Description" translate="yes" xml:space="preserve">
           <source>Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</source>
-          <target state="needs-review-translation">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
+          <target state="translated">Squirtle sitt skall er ikke bare brukt for beskyttelse. Skallet har en avrundet form og riller på overflaten som reduserer motstand i vann, slik at Pokémonen kan svømme i høye hastigheter.</target>
         </trans-unit>
         <trans-unit id="Wartortle.Description" translate="yes" xml:space="preserve">
           <source>Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</source>
@@ -2489,11 +2488,11 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Caterpie.Description" translate="yes" xml:space="preserve">
           <source>Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</source>
-          <target state="needs-review-translation">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
+          <target state="translated">Caterpie har en glupsk appetitt. Den kan sluke blader større enn kroppen sin rett foran øynene dine. Fra antenene sender den ut en forferdelig sterk lukt. </target>
         </trans-unit>
         <trans-unit id="Metapod.Description" translate="yes" xml:space="preserve">
           <source>The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</source>
-          <target state="needs-review-translation">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
+          <target state="translated">Skallet som dekker Pokémonen sin kropp er like hard som jern. Metapod flytte ikke mye. Det ligger stille fordi det forbereder utviklingen sin innenfor det harde skallet.</target>
         </trans-unit>
         <trans-unit id="Butterfree.Description" translate="yes" xml:space="preserve">
           <source>Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</source>
@@ -2501,7 +2500,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Weedle.Description" translate="yes" xml:space="preserve">
           <source>Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</source>
-          <target state="needs-review-translation">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
+          <target state="translated">Weedle har en ekstremt skarp luktesans. Den er i stand til å skille ut sine favoritt blader fra de den misliker ved sniffing med sin store røde nese.</target>
         </trans-unit>
         <trans-unit id="Kakuna.Description" translate="yes" xml:space="preserve">
           <source>Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</source>
@@ -2517,7 +2516,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Pidgeotto.Description" translate="yes" xml:space="preserve">
           <source>Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</source>
-          <target state="needs-review-translation">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
+          <target state="translated">Pidgeotto tar store områder og lager det til sitt eget territorium. Den flyr rundt og patruljerer sitt territorium. Hvis territoriumet blir forstyrret, viser den ingen nåde og vil grundig straffe fienden med sine skarpe klør.</target>
         </trans-unit>
         <trans-unit id="Pidgeot.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</source>
@@ -2525,7 +2524,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Rattata.Description" translate="yes" xml:space="preserve">
           <source>Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</source>
-          <target state="needs-review-translation">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
+          <target state="translated">Rattata er svært forsiktig. Selv når den hviler, lytter den stadig etter lyder ved å bevege ørene. Den er ikke kresen om hvor den bor. Den lager reir overalt!</target>
         </trans-unit>
         <trans-unit id="Raticate.Description" translate="yes" xml:space="preserve">
           <source>Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</source>
@@ -2533,7 +2532,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Spearow.Description" translate="yes" xml:space="preserve">
           <source>Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</source>
-          <target state="needs-review-translation">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
+          <target state="translated">Spearow har et svært høyt rop som kan høres over en kilometer unna. Hvis du hører mange av ropene i et ekko, er det et tegn på at de advarer hverandre for potensiell fare.</target>
         </trans-unit>
         <trans-unit id="Fearow.Description" translate="yes" xml:space="preserve">
           <source>Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</source>
@@ -2553,7 +2552,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Raichu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</source>
-          <target state="translated">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
+          <target state="translated">Denne Pokémonen utstråler en svak elektrisk ladning fra kroppen. Dette gjør at den har en svak glød i mørke. Raichu kan sette halen i bakken for å slippe ut elektrisitet.</target>
         </trans-unit>
         <trans-unit id="Sandshrew.Description" translate="yes" xml:space="preserve">
           <source>Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</source>
@@ -2565,7 +2564,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranFemale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</source>
-          <target state="needs-review-translation">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
+          <target state="translated">Nidoran♀ har pigger med mothaker som sender ut en kraftig gift. Piggene er antatt å ha utviklet seg som beskyttelse for denne lille Pokémonen. Når den blir rasende sender den ut en fryktelig toksin fra hornene.</target>
         </trans-unit>
         <trans-unit id="Nidorina.Description" translate="yes" xml:space="preserve">
           <source>When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</source>
@@ -2577,7 +2576,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranMale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</source>
-          <target state="needs-review-translation">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
+          <target state="translated">Nidoran♂ har utviklet muskler for å flytte ørene rundt omkring. Takket være dem, kan ørene fritt flyttes i alle retninger. Selv den minste lyd, kan ikke unnslippe å bli hørt av ørene.</target>
         </trans-unit>
         <trans-unit id="Nidorino.Description" translate="yes" xml:space="preserve">
           <source>Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</source>
@@ -2597,7 +2596,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="translated">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
+          <target state="translated">Inne i Vulpixs sin kropp, brenner en flamme som aldri går ut. På dagtid, når temperaturen stiger, sender Pokémonen ut flammer fra munnen for å hindre at kroppen blir for varmt.</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>
@@ -2613,7 +2612,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Zubat.Description" translate="yes" xml:space="preserve">
           <source>Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</source>
-          <target state="needs-review-translation">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
+          <target state="translated">Zubat unngår sollys fordi eksponering fører at den blir dårlig. På dagtid oppholder den deg i huler eller under tak i gamle hus. Den sover hengende opp ned.</target>
         </trans-unit>
         <trans-unit id="Golbat.Description" translate="yes" xml:space="preserve">
           <source>Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</source>
@@ -2621,7 +2620,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Oddish.Description" translate="yes" xml:space="preserve">
           <source>Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</source>
-          <target state="needs-review-translation">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
+          <target state="translated">Oddish søker etter fruktbar, næringsrik jord, der den kan plante seg selv. På dagtid, mens den er plantet, er Pokémonen sine føtter antatt å endre form til røtter.</target>
         </trans-unit>
         <trans-unit id="Gloom.Description" translate="yes" xml:space="preserve">
           <source>From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</source>
@@ -2665,7 +2664,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Psyduck.Description" translate="yes" xml:space="preserve">
           <source>If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</source>
-          <target state="translated">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
+          <target state="translated">Hvis den bruker sin mystiske kraft, kan ikke Psyduck huske at den har brukt den. Den klarer ikke forme et minne av en slik hendelse fordi den går inn i en meditativ tilstand. Denne tilstanden er ganske lik dyp søvn.</target>
         </trans-unit>
         <trans-unit id="Golduck.Description" translate="yes" xml:space="preserve">
           <source>Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</source>
@@ -2725,7 +2724,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Bellsprout.Description" translate="yes" xml:space="preserve">
           <source>Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</source>
-          <target state="needs-review-translation">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
+          <target state="translated">Bellsprout har en tynn og fleksibel kropp som lar den svinge og svaie seg for å unngå alle angrep. Den må ikke bli undervurdert. Fra munnen spytter den en korroderende væske som til og med kan smelte jern.</target>
         </trans-unit>
         <trans-unit id="Weepinbell.Description" translate="yes" xml:space="preserve">
           <source>Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</source>
@@ -2833,7 +2832,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Drowzee.Description" translate="yes" xml:space="preserve">
           <source>If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</source>
-          <target state="needs-review-translation">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
+          <target state="translated">Hvis nesen din blir kløende mens du sover, er det et sikkert tegn på at en av denne Pokémonen står ovenfor sengen din for å prøve å ta drømmene dine.</target>
         </trans-unit>
         <trans-unit id="Hypno.Description" translate="yes" xml:space="preserve">
           <source>Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</source>
@@ -3053,7 +3052,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Mew.Description" translate="yes" xml:space="preserve">
           <source>Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</source>
-          <target state="translated">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
+          <target state="needs-review-translation">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
         </trans-unit>
       </group>
     </body>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMONTYPES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMONTYPES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -81,7 +81,7 @@
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/ITEMS.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/ITEMS.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -89,35 +89,35 @@
       <group id="POKEMONGO-UWP/STRINGS/EN-US/ITEMS.RESW" datatype="resx">
         <trans-unit id="D_ItemGreatBall" translate="yes" xml:space="preserve">
           <source>A good, high-performance Poké Ball that provides a higher catch rate than a standard Poké Ball.</source>
-          <target state="translated">En Poké Ball med høy ytelse som gir større sjanse for å fange Pokémon enn en standard Poké Ball.</target>
+          <target state="final">En ball med bedre ytelse enn en standard Poké Ball. Denne ballen gir deg større sjanse for å fange en Pokémon.</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseCool" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseFloral" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseOrdinary" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncenseSpicy" translate="yes" xml:space="preserve">
           <source>Incense with a mysterious fragrance that lures wild Pokémon to your location for 30 minutes</source>
-          <target state="final">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
+          <target state="needs-review-translation">Røkelse med en mystisk duft som lokker ville Pokémon til deg i 30 minutter</target>
         </trans-unit>
         <trans-unit id="D_ItemIncubatorBasic" translate="yes" xml:space="preserve">
           <source>A device that incubates an Egg as you walk until it is ready to hatch. Breaks after 3 uses.</source>
-          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes.</target>
+          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes. Den kan brukes tre ganger.</target>
         </trans-unit>
         <trans-unit id="D_ItemIncubatorBasicUnlimited" translate="yes" xml:space="preserve">
           <source>A device that incubates an Egg as you walk until it is ready to hatch. Unlimited use!</source>
-          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes.</target>
+          <target state="final">En enhet som ruger egg imens du går til det er klart for å klekkes. Den har evig bruk.</target>
         </trans-unit>
         <trans-unit id="D_ItemMasterBall" translate="yes" xml:space="preserve">
           <source>The best Poké Ball with the ultimate level of performance. With it you will catch any Pokémon without fail.</source>
-          <target state="translated">Den beste Poké Ballen du kan få. Med denne Poké Ballen kan du fange hvilken som helst Pokémon uten å mislykkes.</target>
+          <target state="final">Den beste Poké Ballen du kan få. Med denne Poké Ballen kan du fange hvilken som helst Pokémon uten å mislykkes.</target>
         </trans-unit>
         <trans-unit id="D_ItemPokeBall" translate="yes" xml:space="preserve">
           <source>A device for capturing wild Pokémon. It's thrown like a ball at a wild Pokémon, comfortably encapsulating its target.</source>
@@ -125,7 +125,7 @@
         </trans-unit>
         <trans-unit id="D_ItemPotion" translate="yes" xml:space="preserve">
           <source>A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 20 points.</source>
-          <target state="final">En spray-type medisin for behandling av sår. Det gjenoppretter HP av en Pokémon med 20 poeng.</target>
+          <target state="final">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 20 poeng.</target>
         </trans-unit>
         <trans-unit id="D_ItemRevive" translate="yes" xml:space="preserve">
           <source>A medicine that can revive fainted Pokémon. It also restores half of a fainted Pokémon's maximum HP.</source>
@@ -133,7 +133,7 @@
         </trans-unit>
         <trans-unit id="D_ItemUltraBall" translate="yes" xml:space="preserve">
           <source>An ultra-high performance Poké Ball that provides a higher success rate for catching Pokémon than a Great.</source>
-          <target state="translated">En Poké Ball av super kvalitet som gir deg stor skjanse for å fange en Pokémon. Den er enda bedre enn en Great Ball.</target>
+          <target state="final">En Poké Ball av super kvalitet som gir deg stor skjanse for å fange en Pokémon. Den er enda bedre enn en Great Ball.</target>
         </trans-unit>
         <trans-unit id="ItemBlukBerry" translate="yes" xml:space="preserve">
           <source>Bluk Berry</source>
@@ -145,23 +145,23 @@
         </trans-unit>
         <trans-unit id="ItemHyperPotion" translate="yes" xml:space="preserve">
           <source>Hyper Potion</source>
-          <target state="final">Hyper Potion</target>
+          <target state="needs-review-translation">Hyper Potion</target>
         </trans-unit>
         <trans-unit id="ItemIncenseCool" translate="yes" xml:space="preserve">
           <source>Cool Incense</source>
-          <target state="final">Cool Incense</target>
+          <target state="needs-review-translation">Cool Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseFloral" translate="yes" xml:space="preserve">
           <source>Floral Incense</source>
-          <target state="final">Floral Incense</target>
+          <target state="needs-review-translation">Floral Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseOrdinary" translate="yes" xml:space="preserve">
           <source>Incense</source>
-          <target state="final">Incense</target>
+          <target state="needs-review-translation">Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncenseSpicy" translate="yes" xml:space="preserve">
           <source>Spicy Incense</source>
-          <target state="final">Spicy Incense</target>
+          <target state="needs-review-translation">Spicy Incense</target>
         </trans-unit>
         <trans-unit id="ItemIncubatorBasic" translate="yes" xml:space="preserve">
           <source>Incubator</source>
@@ -173,7 +173,7 @@
         </trans-unit>
         <trans-unit id="ItemItemStorageUpgrade" translate="yes" xml:space="preserve">
           <source>Item Storage Upgrade</source>
-          <target state="final">Gjenstand lager oppgradering</target>
+          <target state="final">Gjenstands lager oppgradering</target>
         </trans-unit>
         <trans-unit id="ItemLuckyEgg" translate="yes" xml:space="preserve">
           <source>Lucky Egg</source>
@@ -205,7 +205,7 @@
         </trans-unit>
         <trans-unit id="ItemPokemonStorageUpgrade" translate="yes" xml:space="preserve">
           <source>Pokemon Storage Upgrade</source>
-          <target state="final">Pokémon lager oppgradering</target>
+          <target state="final">Pokélager oppgradering</target>
         </trans-unit>
         <trans-unit id="ItemPotion" translate="yes" xml:space="preserve">
           <source>Potion</source>
@@ -221,7 +221,7 @@
         </trans-unit>
         <trans-unit id="ItemSpecialCamera" translate="yes" xml:space="preserve">
           <source>Special Camera</source>
-          <target state="final">Spesial Kamera</target>
+          <target state="needs-review-translation">Spesial Kamera</target>
         </trans-unit>
         <trans-unit id="ItemSuperPotion" translate="yes" xml:space="preserve">
           <source>Super Potion</source>
@@ -257,48 +257,48 @@
         </trans-unit>
         <trans-unit id="D_ItemLuckyEgg" translate="yes" xml:space="preserve">
           <source>A Lucky Egg that's filled with happiness! Earns double XP for 30 minutes.</source>
-          <target state="translated">Et Egg som er fylt med lykke! Du får dobbel XP i 30 minutter.</target>
+          <target state="final">Et Egg fylt med lykke! Du får dobbel XP i 30 minutter.</target>
         </trans-unit>
         <trans-unit id="D_ItemRazzBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemSpecialCamera" translate="yes" xml:space="preserve">
           <source>When you encounter Pokémon in the wild, you can use your camera to photograph them.</source>
-          <target state="translated">Når du støter Pokémon i naturen kan du bruke kameraet til å fotografere dem.</target>
+          <target state="final">Når du støter Pokémon i naturen kan du bruke kameraet til å fotografere dem.</target>
         </trans-unit>
         <trans-unit id="D_ItemSuperPotion" translate="yes" xml:space="preserve">
           <source>A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 50 points.</source>
-          <target state="translated">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 50 poeng.</target>
+          <target state="final">En spray-type medisin for behandling av sår. Pokémonen sin HP gjenopprettes med 50 poeng.</target>
         </trans-unit>
         <trans-unit id="D_ItemTroyDisk" translate="yes" xml:space="preserve">
           <source>A module that attracts Pokémon to a Pokéstop for 30 min. The effect benefits other people nearby.</source>
-          <target state="translated">En modul som tiltrekker Pokémon til et Pokéstop i 30 minutter. Andre spillere kan også ta nytte av effekten.</target>
+          <target state="final">En modul som tiltrekker Pokémon til et Pokéstop i 30 minutter. Andre spillere kan også ta nytte av effekten.</target>
         </trans-unit>
         <trans-unit id="D_ItemUnknown" translate="yes" xml:space="preserve">
           <source>This item is unknown and may be added in the future.</source>
-          <target state="translated">Denne gjenstanden er ukjent og vil kanskje legges til i fremtiden.</target>
+          <target state="final">Denne gjenstanden er ukjent og vil kanskje legges til i fremtiden.</target>
         </trans-unit>
         <trans-unit id="D_ItemBlukBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemNanabBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemPinapBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
         <trans-unit id="D_ItemWeparBerry" translate="yes" xml:space="preserve">
           <source>Feed this to a Pokémon, and it will be easier to catch on your next throw.</source>
-          <target state="translated">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
+          <target state="final">Om du gir dette til en Pokémon vil den være lettere å fange på ditt neste kast.</target>
         </trans-unit>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -322,7 +322,7 @@
         </trans-unit>
         <trans-unit id="LoginDisclaimerTextBox.Text" translate="yes" xml:space="preserve">
           <source>To login, enter your Username/Email and Password above. If you don't trust this app, please close it now. Niantic may ban you for using this app. Use at your own risk.</source>
-          <target state="final">For å logge inn, må du oppgi Brukernavn/E-post og Passord ovenfor. Hvis du ikke stoler på appen, vennligst lukk den nå. Niantic kan utestenge deg om du bruker appen. Bruk på eget ansvar.</target>
+          <target state="final">For å logge på må du oppgi Brukernavn/E-post og Passord ovenfor. Hvis du ikke stoler på appen, vennligst lukk den nå. Niantic kan utestenge deg om du bruker appen. Bruk på eget ansvar.</target>
         </trans-unit>
         <trans-unit id="NearbyPokemonTextBlock.Text" translate="yes" xml:space="preserve">
           <source>nearby</source>
@@ -389,9 +389,10 @@
           <target state="final">Gjenstander</target>
         </trans-unit>
         <trans-unit id="NumberTextBlock.Text" translate="yes" xml:space="preserve">
-          <source># </source>
-          <target state="final"># </target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the #</note>
+          <source>+ </source>
+          <target state="needs-review-translation"># </target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the +</note>
         </trans-unit>
         <trans-unit id="SlashSpaceCpTextBlock.Text" translate="yes" xml:space="preserve">
           <source>/ CP</source>
@@ -419,7 +420,7 @@
         </trans-unit>
         <trans-unit id="StartDateTextBlock.Text" translate="yes" xml:space="preserve">
           <source>START DATE</source>
-          <target state="final">START DATO</target>
+          <target state="final">STARTDATO</target>
         </trans-unit>
         <trans-unit id="IncubatorsTextBlock.Text" translate="yes" xml:space="preserve">
           <source>INCUBATORS</source>
@@ -476,7 +477,7 @@
         </trans-unit>
         <trans-unit id="EggDetailTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Use an incubator to incubate the Egg.</source>
-          <target state="final">Bruk en inkubator for å klekke Egget.</target>
+          <target state="final">Bruk en Inkubator for å klekke Egget.</target>
         </trans-unit>
         <trans-unit id="PokedexCaught.Text" translate="yes" xml:space="preserve">
           <source>Caught:</source>
@@ -520,7 +521,7 @@
         </trans-unit>
         <trans-unit id="SettingsRememberMapZoomTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Remember Map Zoom</source>
-          <target state="final">Husk Kart Zoom</target>
+          <target state="needs-review-translation">Husk Kart Zoom</target>
         </trans-unit>
         <trans-unit id="TransferTextBlock.Text" translate="yes" xml:space="preserve">
           <source>TRANSFER</source>
@@ -532,7 +533,7 @@
         </trans-unit>
         <trans-unit id="SettingsLanguageTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="final">Sprøk</target>
+          <target state="final">Språk</target>
         </trans-unit>
         <trans-unit id="SettingsCompassEnabledTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Use compass</source>
@@ -540,16 +541,25 @@
         </trans-unit>
         <trans-unit id="SettingsLiveTileTextBlock.Text" translate="yes" xml:space="preserve">
           <source>Live Tile Mode</source>
-          <target state="final">Live Flis Modus</target>
+          <target state="final">Live Flis</target>
         </trans-unit>
         <trans-unit id="FavoriteTextBlock.Text" translate="yes" xml:space="preserve">
           <source>FAVORITE</source>
           <target state="final">FAVORITT</target>
         </trans-unit>
+        <trans-unit id="AppraiseTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>APPRAISE</source>
+          <target state="needs-review-translation">UNDERSØK</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
+        </trans-unit>
+        <trans-unit id="AwardedExperienceTextBlock.Text" translate="yes" xml:space="preserve">
+          <source>Experience</source>
+          <target state="new">XP</target>
+        </trans-unit>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/ACHIEVEMENTS.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/ACHIEVEMENTS.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -557,232 +567,232 @@
       <group id="POKEMONGO-UWP/STRINGS/EN-US/ACHIEVEMENTS.RESW" datatype="resx">
         <trans-unit id="BadgeBattleAttackWon" translate="yes" xml:space="preserve">
           <source>Battle Girl</source>
-          <target state="translated">Utfordrer</target>
+          <target state="final">Utfordrer</target>
         </trans-unit>
         <trans-unit id="BadgeBattleAttackWonDescription" translate="yes" xml:space="preserve">
           <source>Won {0} gym battles</source>
-          <target state="translated">{0} Pokégym Kamper Vunnet</target>
+          <target state="final">{0} Pokégym Kamper Vunnet</target>
         </trans-unit>
         <trans-unit id="BadgeBattleTrainingWon" translate="yes" xml:space="preserve">
           <source>Ace Trainer</source>
-          <target state="translated">Erfaren trener</target>
+          <target state="final">Profesjonell</target>
         </trans-unit>
         <trans-unit id="BadgeBattleTrainingWonDescription" translate="yes" xml:space="preserve">
           <source>Won {0} training battles</source>
-          <target state="translated">{0} Treningskamper Vunnet</target>
+          <target state="final">{0} Treningskamper Vunnet</target>
         </trans-unit>
         <trans-unit id="BadgeBigMagikarp" translate="yes" xml:space="preserve">
           <source>Fisherman</source>
-          <target state="translated">Fisker</target>
+          <target state="final">Fisker</target>
         </trans-unit>
         <trans-unit id="BadgeBigMagikarpDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Magikarp</source>
-          <target state="translated">{0} Magikarp fanget</target>
+          <target state="final">{0} Magikarp fanget</target>
         </trans-unit>
         <trans-unit id="BadgeCaptureTotal" translate="yes" xml:space="preserve">
           <source>Collector</source>
-          <target state="translated">Samler</target>
+          <target state="final">Samler</target>
         </trans-unit>
         <trans-unit id="BadgeCaptureTotalDescription" translate="yes" xml:space="preserve">
           <source>Captured {0} Pokemon</source>
-          <target state="translated">{0} Pokémon fanget</target>
+          <target state="final">{0} Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="BadgeEvolvedTotal" translate="yes" xml:space="preserve">
           <source>Scientist</source>
-          <target state="translated">Forsker</target>
+          <target state="final">Forsker</target>
         </trans-unit>
         <trans-unit id="BadgeEvolvedTotalDescription" translate="yes" xml:space="preserve">
           <source>Evolved {0} Pokémon</source>
-          <target state="translated">{0} Pokémon utviklet</target>
+          <target state="final">{0} Pokémon utviklet</target>
         </trans-unit>
         <trans-unit id="BadgeHatchedTotal" translate="yes" xml:space="preserve">
           <source>Breeder</source>
-          <target state="translated">Oppdretter</target>
+          <target state="final">Oppdretter</target>
         </trans-unit>
         <trans-unit id="BadgeHatchedTotalDescription" translate="yes" xml:space="preserve">
           <source>Hatched {0} Pokemon</source>
-          <target state="translated">{0} Pokémon klekket</target>
+          <target state="final">{0} Pokémon klekket</target>
         </trans-unit>
         <trans-unit id="BadgePikachu" translate="yes" xml:space="preserve">
           <source>Pikachu</source>
-          <target state="translated">Pikachu Fan</target>
+          <target state="final">Pikachu Fan</target>
         </trans-unit>
         <trans-unit id="BadgePikachuDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Pikachu</source>
-          <target state="translated">{0} Pikachu fanget</target>
+          <target state="final">{0} Pikachu fanget</target>
         </trans-unit>
         <trans-unit id="BadgePokedexEntries" translate="yes" xml:space="preserve">
           <source>Kanto</source>
-          <target state="translated">Oppdager</target>
+          <target state="final">Oppdager</target>
         </trans-unit>
         <trans-unit id="BadgePokedexEntriesDescription" translate="yes" xml:space="preserve">
           <source>Registered {0} Pokemon in the Pokedex</source>
-          <target state="translated">{0} Pokémon registrert i Pokédexen</target>
+          <target state="final">{0} Pokémon registrert i Pokédexen</target>
         </trans-unit>
         <trans-unit id="BadgePokestopsVisited" translate="yes" xml:space="preserve">
           <source>Backpacker</source>
-          <target state="translated">Dårlig Tid?</target>
+          <target state="final">Hyppig</target>
         </trans-unit>
         <trans-unit id="BadgePokestopsVisitedDescription" translate="yes" xml:space="preserve">
           <source>Visited {0} Pokestops</source>
-          <target state="translated">{0} Pokéstop Besøkt</target>
+          <target state="final">{0} Pokéstop Besøkt</target>
         </trans-unit>
         <trans-unit id="BadgeSmallRattata" translate="yes" xml:space="preserve">
           <source>Youngster</source>
-          <target state="translated">Unggutt</target>
+          <target state="final">Unggutt</target>
         </trans-unit>
         <trans-unit id="BadgeSmallRattataDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} small Rattata</source>
-          <target state="translated">{0} Små Rattata fanget</target>
+          <target state="final">{0} Små Rattata fanget</target>
         </trans-unit>
         <trans-unit id="BadgeTravelKm" translate="yes" xml:space="preserve">
           <source>Jogger</source>
-          <target state="translated">Jogger</target>
+          <target state="final">Jogger</target>
         </trans-unit>
         <trans-unit id="BadgeTravelKmDescription" translate="yes" xml:space="preserve">
           <source>Walked {0} km</source>
-          <target state="translated">{0} km gått</target>
+          <target state="final">{0} km gått</target>
         </trans-unit>
         <trans-unit id="Bug" translate="yes" xml:space="preserve">
           <source>Bug Catcher</source>
-          <target state="translated">Insektfanger</target>
+          <target state="final">Insektfanger</target>
         </trans-unit>
         <trans-unit id="BugDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Bug Pokemon</source>
-          <target state="translated">{0} Insekt-type Pokémon fanget</target>
+          <target state="final">{0} Insekt-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Dragon" translate="yes" xml:space="preserve">
           <source>Dragon Tamer</source>
-          <target state="translated">Dragetemmer</target>
+          <target state="final">Dragetemmer</target>
         </trans-unit>
         <trans-unit id="DragonDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Dragon Pokemon</source>
-          <target state="translated">{0} Drage-type Pokémon fanget</target>
+          <target state="final">{0} Drage-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Electric" translate="yes" xml:space="preserve">
           <source>Rocker</source>
-          <target state="translated">Elektriker</target>
+          <target state="final">Elektriker</target>
         </trans-unit>
         <trans-unit id="ElectricDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Electric Pokemon</source>
-          <target state="translated">{0} Elektrisk-type Pokémon fanget</target>
+          <target state="final">{0} Elektrisk-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fairy" translate="yes" xml:space="preserve">
           <source>Fairy Tale Girl</source>
-          <target state="translated">Eventyrtid</target>
+          <target state="final">Eventyrtid</target>
         </trans-unit>
         <trans-unit id="FairyDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fairy Pokemon</source>
-          <target state="translated">{0} Fe-type Pokémon fanget</target>
+          <target state="final">{0} Fe-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fighting" translate="yes" xml:space="preserve">
           <source>Black Belt</source>
-          <target state="translated">Svart Belte</target>
+          <target state="final">Svart Belte</target>
         </trans-unit>
         <trans-unit id="FightingDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fighting Pokemon</source>
-          <target state="translated">{0} Sloss-type Pokémon fanget</target>
+          <target state="final">{0} Sloss-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Fire" translate="yes" xml:space="preserve">
           <source>Kindler</source>
-          <target state="translated">Pyroman</target>
+          <target state="final">Pyroman</target>
         </trans-unit>
         <trans-unit id="FireDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Fire Pokemon</source>
-          <target state="translated">{0} Brann-type Pokémon fanget</target>
+          <target state="final">{0} Brann-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Flying" translate="yes" xml:space="preserve">
           <source>Bird Keeper</source>
-          <target state="translated">Fuglepasser</target>
+          <target state="final">Fuglepasser</target>
         </trans-unit>
         <trans-unit id="FlyingDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Flying Pokemon</source>
-          <target state="translated">{0} Fly-type Pokémon fanget</target>
+          <target state="final">{0} Fly-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ghost" translate="yes" xml:space="preserve">
           <source>Hex Maniac</source>
-          <target state="translated">Spøkelsesjeger</target>
+          <target state="final">Spøkelsesjeger</target>
         </trans-unit>
         <trans-unit id="GhostDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ghost Pokemon</source>
-          <target state="translated">{0} Spøkelse-type Pokémon fanget</target>
+          <target state="final">{0} Spøkelse-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Grass" translate="yes" xml:space="preserve">
           <source>Gardener</source>
-          <target state="translated">Gartner</target>
+          <target state="final">Gartner</target>
         </trans-unit>
         <trans-unit id="GrassDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Grass Pokemon</source>
-          <target state="translated">{0} Gress-type Pokémon fanget</target>
+          <target state="final">{0} Gress-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ground" translate="yes" xml:space="preserve">
           <source>Ruin Maniac</source>
-          <target state="translated">Under Jorden</target>
+          <target state="final">Underjordisk</target>
         </trans-unit>
         <trans-unit id="GroundDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ground Pokemon</source>
-          <target state="translated">{0} Jord-type Pokémon fanget</target>
+          <target state="final">{0} Jord-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Ice" translate="yes" xml:space="preserve">
           <source>Skier</source>
-          <target state="translated">Skiløper</target>
+          <target state="final">Skiløper</target>
         </trans-unit>
         <trans-unit id="IceDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Ice Pokemon</source>
-          <target state="translated">{0} Is-type Pokémon fanget</target>
+          <target state="final">{0} Is-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Normal" translate="yes" xml:space="preserve">
           <source>School Kid</source>
-          <target state="translated">Skoleelev</target>
+          <target state="final">Skoleelev</target>
         </trans-unit>
         <trans-unit id="NormalDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Normal Pokemon</source>
-          <target state="translated">{0} Normal-type Pokémon fanget</target>
+          <target state="final">{0} Normal-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Poison" translate="yes" xml:space="preserve">
           <source>Punk Girl</source>
-          <target state="translated">Giftig Samling</target>
+          <target state="final">Giftig</target>
         </trans-unit>
         <trans-unit id="PoisonDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Poison Pokemon</source>
-          <target state="translated">{0} Gift-type Pokémon fanget</target>
+          <target state="final">{0} Gift-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Psychic" translate="yes" xml:space="preserve">
           <source>Psychic</source>
-          <target state="translated">Psykiater</target>
+          <target state="final">Psykiater</target>
         </trans-unit>
         <trans-unit id="PsychicDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Psychic Pokemon</source>
-          <target state="translated">{0} Psykisk-type Pokémon fanget</target>
+          <target state="final">{0} Psykisk-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Rock" translate="yes" xml:space="preserve">
           <source>Hiker</source>
-          <target state="translated">Turgåer</target>
+          <target state="final">Turgåer</target>
         </trans-unit>
         <trans-unit id="RockDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Rock Pokemon</source>
-          <target state="translated">{0} Stein-type Pokémon fanget</target>
+          <target state="final">{0} Stein-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Steel" translate="yes" xml:space="preserve">
           <source>Depot Agent</source>
-          <target state="translated">Metallarbeider</target>
+          <target state="final">Mekaniker</target>
         </trans-unit>
         <trans-unit id="SteelDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Steel Pokemon</source>
-          <target state="translated">{0} Metall-type Pokémon fanget</target>
+          <target state="final">{0} Metall-type Pokémon fanget</target>
         </trans-unit>
         <trans-unit id="Water" translate="yes" xml:space="preserve">
           <source>Swimmer</source>
-          <target state="translated">Svømmer</target>
+          <target state="final">Svømmer</target>
         </trans-unit>
         <trans-unit id="WaterDescription" translate="yes" xml:space="preserve">
           <source>Caught {0} Water Pokemon</source>
-          <target state="translated">{0} Vann-type Pokémon fanget</target>
+          <target state="final">{0} Vann-type Pokémon fanget</target>
         </trans-unit>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/CODERESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/CODERESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -798,36 +808,36 @@
         </trans-unit>
         <trans-unit id="PokemonFledText" translate="yes" xml:space="preserve">
           <source>{0} fled</source>
-          <target state="translated">{0} flyktet
+          <target state="final">{0} flyktet
 </target>
         </trans-unit>
         <trans-unit id="GettingGpsSignalText" translate="yes" xml:space="preserve">
           <source>Getting GPS signal...</source>
-          <target state="translated">Søker GPS signal...</target>
+          <target state="final">Søker GPS signal...</target>
         </trans-unit>
         <trans-unit id="GettingUserDataText" translate="yes" xml:space="preserve">
           <source>Getting user data...</source>
-          <target state="translated">Henter brukerdata...</target>
+          <target state="final">Henter brukerdata...</target>
         </trans-unit>
         <trans-unit id="GoogleErrorText" translate="yes" xml:space="preserve">
           <source>Google returned error: </source>
-          <target state="translated">Google returnerte feil: </target>
+          <target state="final">Google returnerte feil: </target>
         </trans-unit>
         <trans-unit id="GoogleNotRespondingText" translate="yes" xml:space="preserve">
           <source>Google is not responding, please try again later.</source>
-          <target state="translated">Google svarer ikke, vennligst prøv igjen senere.</target>
+          <target state="final">Google svarer ikke, vennligst prøv igjen senere.</target>
         </trans-unit>
         <trans-unit id="LoginExpired" translate="yes" xml:space="preserve">
           <source>Previous login expired.</source>
-          <target state="translated">Tidligere innlogging har utløpt.</target>
+          <target state="final">Tidligere pålogging har utløpt.</target>
         </trans-unit>
         <trans-unit id="LoadingEncounterText" translate="yes" xml:space="preserve">
           <source>Loading encounter with {0}</source>
-          <target state="translated">Laster møte med {0}</target>
+          <target state="final">Laster møte med {0}</target>
         </trans-unit>
         <trans-unit id="LoggingInText" translate="yes" xml:space="preserve">
           <source>Logging in...</source>
-          <target state="final">Logger inn...</target>
+          <target state="final">Logger på...</target>
         </trans-unit>
         <trans-unit id="LoginFailedText" translate="yes" xml:space="preserve">
           <source>Login failed, please try again.</source>
@@ -835,25 +845,24 @@
         </trans-unit>
         <trans-unit id="NoText" translate="yes" xml:space="preserve">
           <source>NO</source>
-          <target state="needs-review-translation">Nei</target>
+          <target state="final">NEI</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NoGpsPermissionsText" translate="yes" xml:space="preserve">
           <source>We need GPS permissions to run the game, please enable it and try again.</source>
-          <target state="translated">Vi trenger GPS tillatelse for å starte spillet, vennligst aktiver det og prøv på nytt.</target>
+          <target state="final">Vi trenger GPS tillatelse for å starte spillet, vennligst aktiver det og prøv på nytt.</target>
         </trans-unit>
         <trans-unit id="PokemonRanAwayText" translate="yes" xml:space="preserve">
           <source>Pokémon ran away, sorry :(</source>
-          <target state="translated">Pokémonen rømte, beklager :(</target>
+          <target state="final">Pokémonen rømte, beklager :(</target>
         </trans-unit>
         <trans-unit id="PtcDownText" translate="yes" xml:space="preserve">
           <source>PTC login is probably down, please retry later.</source>
-          <target state="translated">PTC pålogging er sannsynligvis nede, vennligst prøv på nytt senere.</target>
+          <target state="final">PTC påloggingen er sannsynligvis nede, vennligst prøv på nytt senere.</target>
         </trans-unit>
         <trans-unit id="SomethingWentWrongText" translate="yes" xml:space="preserve">
           <source>Something went wrong and app may be unstable now. Do you want to logout and try again?</source>
-          <target state="translated">Noe gikk galt og appen kan være ustabil. Vil du å logge ut og prøve på nytt?</target>
+          <target state="final">Noe gikk galt og appen kan være ustabil. Vil du logge ut og prøve på nytt?</target>
         </trans-unit>
         <trans-unit id="TimeFormat" translate="yes" xml:space="preserve">
           <source>hh:mm tt</source>
@@ -866,28 +875,27 @@
         <trans-unit id="UpdatedVersionText" translate="yes" xml:space="preserve">
           <source>An updated version {0} is available. Do you want to update?
 {1}</source>
-          <target state="translated">En oppdatert versjon {0} er tilgjengelig. Vil du oppdatere?
+          <target state="final">En oppdatert versjon {0} er tilgjengelig. Vil du oppdatere?
 {1}</target>
         </trans-unit>
         <trans-unit id="UpdateFailedText" translate="yes" xml:space="preserve">
           <source>Update failed: {0}
 Open page with installation files for manual install?</source>
-          <target state="translated">Oppdatering mislykkes: {0}
+          <target state="final">Oppdatering mislykkes: {0}
 Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target>
         </trans-unit>
         <trans-unit id="UpdateInstallingText" translate="yes" xml:space="preserve">
           <source>Installing update, app is restarting...</source>
-          <target state="translated">Installerer oppdatering, appen starter på nytt...</target>
+          <target state="final">Installerer oppdatering, appen starter på nytt...</target>
         </trans-unit>
         <trans-unit id="WrongUsernameText" translate="yes" xml:space="preserve">
           <source>Wrong username/password or offline server, please try again.</source>
-          <target state="translated">Feil brukernavn/passord eller frakoblet server, vennligst prøv på nytt.</target>
+          <target state="final">Feil brukernavn/passord eller offline server, vennligst prøv på nytt.</target>
         </trans-unit>
         <trans-unit id="YesText" translate="yes" xml:space="preserve">
           <source>YES</source>
-          <target state="needs-review-translation">Ja</target>
+          <target state="final">JA</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="InstinctTeamText" translate="yes" xml:space="preserve">
           <source>Instinct</source>
@@ -895,7 +903,7 @@ Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target
         </trans-unit>
         <trans-unit id="NoTeamText" translate="yes" xml:space="preserve">
           <source>No Team</source>
-          <target state="final">Ingen lag</target>
+          <target state="final">Ingen Lag</target>
         </trans-unit>
         <trans-unit id="ValorTeamText" translate="yes" xml:space="preserve">
           <source>Valor</source>
@@ -907,174 +915,191 @@ Vil du åpne nettsiden med installasjonsfilene for manuell installasjon?</target
         </trans-unit>
         <trans-unit id="TransferPokemonSuccessText" translate="yes" xml:space="preserve">
           <source>Transfer succeeded! Got a {0} Candy from the Professor.</source>
-          <target state="translated">Overføring fullført! Du fikk en {0} Candy fra Professoren.</target>
+          <target state="final">Overføring fullført! Du fikk en {0} Candy fra Professoren.</target>
         </trans-unit>
         <trans-unit id="TransferPokemonWarningText" translate="yes" xml:space="preserve">
           <source>You can't take it back after it's transferred to the Professor.</source>
-          <target state="translated">Du kan ikke få den tilbake etter den er overført til Professoren.</target>
+          <target state="final">Du kan ikke få den tilbake etter den er overført til Professoren.</target>
         </trans-unit>
         <trans-unit id="ActivityUnknown" translate="yes" xml:space="preserve">
           <source>Unknown</source>
-          <target state="translated">Ukjent</target>
+          <target state="final">Ukjent</target>
         </trans-unit>
         <trans-unit id="ActivityCatchPokemon" translate="yes" xml:space="preserve">
           <source>Pokémon Caught</source>
-          <target state="translated">Pokémon Fanget</target>
+          <target state="final">Pokémon Fanget</target>
         </trans-unit>
         <trans-unit id="ActivityCatchLegendPokemon" translate="yes" xml:space="preserve">
           <source>Catch Legendary Pokémon</source>
-          <target state="translated">Fang en Legendarisk Pokémon</target>
+          <target state="final">Fang en Legendarisk Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityFleePokemon" translate="yes" xml:space="preserve">
           <source>Pokémon Fled</source>
-          <target state="translated">Pokémonen Flyktet</target>
+          <target state="final">Pokémonen Flyktet</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatFort" translate="yes" xml:space="preserve">
           <source>Defeat Fort</source>
-          <target state="new">Defeat Fort</target>
+          <target state="needs-review-translation">Defeat Fort</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityEvolvePokemon" translate="yes" xml:space="preserve">
           <source>Evolve a Pokémon</source>
-          <target state="translated">Utvikle en Pokémon</target>
+          <target state="needs-review-translation">Utvikle en Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEgg" translate="yes" xml:space="preserve">
           <source>Egg Hatched!</source>
-          <target state="translated">Egg klekket!</target>
+          <target state="final">Egg klekket!</target>
         </trans-unit>
         <trans-unit id="ActivityWalkKm" translate="yes" xml:space="preserve">
           <source>Walk Km</source>
-          <target state="translated">Gå km</target>
+          <target state="final">Gå km</target>
         </trans-unit>
         <trans-unit id="ActivityPokedexEntryNew" translate="yes" xml:space="preserve">
           <source>New Pokémon</source>
-          <target state="translated">Ny Pokémon</target>
+          <target state="final">Ny Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivityCatchFirstThrow" translate="yes" xml:space="preserve">
           <source>First Throw</source>
-          <target state="translated">Første Kast</target>
+          <target state="final">Første Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchNiceThrow" translate="yes" xml:space="preserve">
           <source>Nice Throw</source>
-          <target state="translated">Greit Kast</target>
+          <target state="final">Greit Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchGreatThrow" translate="yes" xml:space="preserve">
           <source>Great Throw</source>
-          <target state="translated">Nydelig Kast</target>
+          <target state="final">Nydelig Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchExcellentThrow" translate="yes" xml:space="preserve">
           <source>Excellent Throw</source>
-          <target state="translated">Perfekt Kast</target>
+          <target state="final">Perfekt Kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchCurveball" translate="yes" xml:space="preserve">
           <source>Curveball</source>
-          <target state="translated">Kurvet kast</target>
+          <target state="final">Kurvet kast</target>
         </trans-unit>
         <trans-unit id="ActivityCatchFirstCatchOfDay" translate="yes" xml:space="preserve">
           <source>First Catch of Day!</source>
-          <target state="translated">Dagens Første Fangst!</target>
+          <target state="final">Dagens Første Fangst!</target>
         </trans-unit>
         <trans-unit id="ActivityCatchMilestone" translate="yes" xml:space="preserve">
           <source>Catch Milestone</source>
-          <target state="translated">Fang Milestone</target>
+          <target state="needs-review-translation">Fang Milestone</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityTrainPokemon" translate="yes" xml:space="preserve">
           <source>Train Pokémon</source>
-          <target state="translated">Tren Pokémon</target>
+          <target state="final">Tren Pokémon</target>
         </trans-unit>
         <trans-unit id="ActivitySearchFort" translate="yes" xml:space="preserve">
           <source>Search Fort</source>
-          <target state="new">Search Fort</target>
+          <target state="needs-review-translation">Search Fort</target>
           <note from="MultilingualEditor" annotates="source" priority="4">Need to check ingame</note>
         </trans-unit>
         <trans-unit id="ActivityReleasePokemon" translate="yes" xml:space="preserve">
           <source>Release Pokémon</source>
-          <target state="translated">Slipp Pokémon Løs</target>
+          <target state="final">Slipp Pokémon Løs</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggSmallBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Small Bonus</source>
-          <target state="translated">Bonus For Lite Egg Klekket</target>
+          <target state="final">Bonus For Lite Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggMediumBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Medium Bonus</source>
-          <target state="translated">Bonus For Mellomstort Egg Klekket</target>
+          <target state="final">Bonus For Mellomstort Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityHatchEggLargeBonus" translate="yes" xml:space="preserve">
           <source>Hatch Egg Large Bonus</source>
-          <target state="translated">Bonus For Stort Egg Klekket</target>
+          <target state="final">Bonus For Stort Egg Klekket</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatGymDefender" translate="yes" xml:space="preserve">
           <source>Defeat Gym Defender</source>
-          <target state="translated">Slå Pokégym Forsvareren</target>
+          <target state="needs-review-translation">Slå Pokégym Forsvareren</target>
         </trans-unit>
         <trans-unit id="ActivityDefeatGymLeader" translate="yes" xml:space="preserve">
           <source>Defeat Gym Leader</source>
-          <target state="translated">Slå Pokégym Lederen</target>
+          <target state="needs-review-translation">Slå Pokégym Lederen</target>
         </trans-unit>
         <trans-unit id="Combat" translate="yes" xml:space="preserve">
           <source>Combat</source>
-          <target state="translated">Kamp</target>
+          <target state="final">Styrke</target>
         </trans-unit>
         <trans-unit id="Date" translate="yes" xml:space="preserve">
           <source>Date</source>
-          <target state="translated">Dato</target>
+          <target state="final">Dato</target>
         </trans-unit>
         <trans-unit id="Fav" translate="yes" xml:space="preserve">
           <source>Favorite</source>
-          <target state="translated">Favoritt</target>
+          <target state="final">Favoritt</target>
         </trans-unit>
         <trans-unit id="Health" translate="yes" xml:space="preserve">
           <source>Health</source>
-          <target state="translated">Helse</target>
+          <target state="final">HP</target>
         </trans-unit>
         <trans-unit id="Name" translate="yes" xml:space="preserve">
           <source>Name</source>
-          <target state="translated">Navn</target>
+          <target state="final">Navn</target>
         </trans-unit>
         <trans-unit id="Number" translate="yes" xml:space="preserve">
           <source>Number</source>
-          <target state="translated">Nummer</target>
+          <target state="final">Nummer</target>
         </trans-unit>
         <trans-unit id="PokemonInventoryFullText" translate="yes" xml:space="preserve">
           <source>Your Pokémon inventory is full, transfer some Pokémon before trying to catch {0}.</source>
-          <target state="translated">Ditt Pokélager er fullt, overfør noen Pokémon før du prøver å fange {0}.</target>
+          <target state="final">Ditt Pokélager er fullt, overfør noen Pokémon før du prøver å fange {0}.</target>
         </trans-unit>
         <trans-unit id="WaitingForNetworkText" translate="yes" xml:space="preserve">
           <source>Waiting for network to be back...</source>
-          <target state="translated">Venter på at nettverket kommer tilbake...</target>
+          <target state="final">Venter på at nettverket kommer tilbake...</target>
         </trans-unit>
         <trans-unit id="EggHatchMessage" translate="yes" xml:space="preserve">
           <source>An Egg hatched into a {0}.
 You also got {1} Stardust, {2} Candy and {3} XP.</source>
-          <target state="translated">Et Egg ble klekket til en {0}.
+          <target state="final">Et Egg klekket ut en {0}.
 Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="EvolvePokemonWarningText" translate="yes" xml:space="preserve">
           <source>Do you want to evolve {0}?</source>
-          <target state="translated">Vil du utvikle {0}?</target>
+          <target state="final">Vil du utvikle {0}?</target>
         </trans-unit>
         <trans-unit id="PowerUpPokemonWarningText" translate="yes" xml:space="preserve">
           <source>Do you want to use a power up for {0}?</source>
-          <target state="translated">Vil du øke kraften til {0}?</target>
+          <target state="final">Vil du øke kraften til {0}?</target>
         </trans-unit>
         <trans-unit id="TransferPokemonWarningTitle" translate="yes" xml:space="preserve">
           <source>Do you really want to transfer {0} to the Professor?</source>
-          <target state="translated">Vil du virkelig overføre {0} til Professoren?</target>
+          <target state="final">Vil du virkelig overføre {0} til Professoren?</target>
         </trans-unit>
         <trans-unit id="CancelText" translate="yes" xml:space="preserve">
           <source>CANCEL</source>
-          <target state="new">CANCEL</target>
+          <target state="final">AVBRYT</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="ItemDiscardWarningText" translate="yes" xml:space="preserve">
           <source>Discard {0}?</source>
-          <target state="new">Discard {0}?</target>
+          <target state="needs-review-translation">Kaste {0}?</target>
+        </trans-unit>
+        <trans-unit id="SetNickName" translate="yes" xml:space="preserve">
+          <source>Set Nickname</source>
+          <target state="final">Angi Kallenavn</target>
+        </trans-unit>
+        <trans-unit id="OkText" translate="yes" xml:space="preserve">
+          <source>O. K.</source>
+          <target state="needs-review-translation">O. K.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Space between . and K</note>
+        </trans-unit>
+        <trans-unit id="PokemonEncounterErrorText" translate="yes" xml:space="preserve">
+          <source>There was an error loading the encounter with {0}, please try again later.</source>
+          <target state="new">There was an error loading the encounter with {0}, please try again later.</target>
+        </trans-unit>
+        <trans-unit id="PokemonEncounterNotInRangeText" translate="yes" xml:space="preserve">
+          <source>{0} is not in catch range anymore.</source>
+          <target state="new">{0} is not in catch range anymore.</target>
         </trans-unit>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMON.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMON.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -1691,7 +1716,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMONMOVES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEMONMOVES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -2420,7 +2445,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
       </group>
     </body>
   </file>
-  <file datatype="xml" source-language="en-US" target-language="nb-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEDEX.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+  <file datatype="xml" source-language="en-US" target-language="nn-NO" original="POKEMONGO-UWP/STRINGS/EN-US/POKEDEX.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
       <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.1605.0" tool-company="Microsoft" />
     </header>
@@ -2428,607 +2453,607 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
       <group id="POKEMONGO-UWP/STRINGS/EN-US/POKEDEX.RESW" datatype="resx">
         <trans-unit id="Bulbasaur.Description" translate="yes" xml:space="preserve">
           <source>Bulbasaur can be seen napping in bright sunlight. There is a seed on its back. By soaking up the sun’s rays, the seed grows progressively larger.</source>
-          <target state="translated">Bulbasaur kan ses slappe av i sterkt sollys. Den har et frø på ryggen. Ved å absorbere solstråler kan frøet vokse større.</target>
+          <target state="final">Bulbasaur kan bli observert slappe av i sterkt sollys. Den har et frø på ryggen. Ved å absorbere solstråler kan frøet vokse større.</target>
         </trans-unit>
         <trans-unit id="Ivysaur.Description" translate="yes" xml:space="preserve">
           <source>There is a bud on this Pokémon’s back. To support its weight, Ivysaur’s legs and trunk grow thick and strong. If it starts spending more time lying in the sunlight, it’s a sign that the bud will bloom into a large flower soon.</source>
-          <target state="translated">Det er en spire på ryggen til denne Pokémonen. For å støtte vekten sin har Ivysaur sterke føtter og en tykk stilk som bærer spiren. Hvis Pokémonen bruker ekstra mye tid i solen er det et tegn på at spiren snart vil blomstre i en stor blomst.</target>
+          <target state="final">Det er en spire på ryggen til denne Pokémonen. For å støtte vekten sin har Ivysaur sterke føtter og en tykk stilk som bærer spiren. Hvis Pokémonen bruker ekstra mye tid i solen er det et tegn på at spiren snart vil blomstre i en stor blomst.</target>
         </trans-unit>
         <trans-unit id="Venusaur.Description" translate="yes" xml:space="preserve">
           <source>There is a large flower on Venusaur’s back. The flower is said to take on vivid colors if it gets plenty of nutrition and sunlight. The flower’s aroma soothes the emotions of people.</source>
-          <target state="translated">Det er en stor blomst på Venusaur sin rygg. Det sies at blomsten får levende og stærke farger hvis det får rikelig med ernæring og sollys. Blomstens aroma kan roe ned folks følelser.</target>
+          <target state="final">Det er en stor blomst på Venusaur sin rygg. Det sies at blomsten får levende og stærke farger hvis det får rikelig med ernæring og sollys. Blomstens aroma kan roe ned folk sine følelser.</target>
         </trans-unit>
         <trans-unit id="Charmander.Description" translate="yes" xml:space="preserve">
           <source>The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</source>
-          <target state="new">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
+          <target state="needs-review-translation">The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</target>
         </trans-unit>
         <trans-unit id="Charmeleon.Description" translate="yes" xml:space="preserve">
           <source>Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</source>
-          <target state="new">Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</target>
+          <target state="needs-review-translation">Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</target>
         </trans-unit>
         <trans-unit id="Charizard.Description" translate="yes" xml:space="preserve">
           <source>Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</source>
-          <target state="new">Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</target>
+          <target state="needs-review-translation">Charizard flies around the sky in search of powerful opponents. It breathes fire of such great heat that it melts anything. However, it never turns its fiery breath on any opponent weaker than itself.</target>
         </trans-unit>
         <trans-unit id="Squirtle.Description" translate="yes" xml:space="preserve">
           <source>Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</source>
-          <target state="new">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
+          <target state="needs-review-translation">Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</target>
         </trans-unit>
         <trans-unit id="Wartortle.Description" translate="yes" xml:space="preserve">
           <source>Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</source>
-          <target state="new">Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</target>
+          <target state="needs-review-translation">Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</target>
         </trans-unit>
         <trans-unit id="Blastoise.Description" translate="yes" xml:space="preserve">
           <source>Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</source>
-          <target state="new">Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</target>
+          <target state="needs-review-translation">Blastoise has water spouts that protrude from its shell. The water spouts are very accurate. They can shoot bullets of water with enough accuracy to strike empty cans from a distance of over 160 feet.</target>
         </trans-unit>
         <trans-unit id="Caterpie.Description" translate="yes" xml:space="preserve">
           <source>Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</source>
-          <target state="new">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
+          <target state="needs-review-translation">Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</target>
         </trans-unit>
         <trans-unit id="Metapod.Description" translate="yes" xml:space="preserve">
           <source>The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</source>
-          <target state="new">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
+          <target state="needs-review-translation">The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</target>
         </trans-unit>
         <trans-unit id="Butterfree.Description" translate="yes" xml:space="preserve">
           <source>Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</source>
-          <target state="new">Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</target>
+          <target state="needs-review-translation">Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</target>
         </trans-unit>
         <trans-unit id="Weedle.Description" translate="yes" xml:space="preserve">
           <source>Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</source>
-          <target state="new">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
+          <target state="needs-review-translation">Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</target>
         </trans-unit>
         <trans-unit id="Kakuna.Description" translate="yes" xml:space="preserve">
           <source>Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</source>
-          <target state="new">Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</target>
+          <target state="needs-review-translation">Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</target>
         </trans-unit>
         <trans-unit id="Beedrill.Description" translate="yes" xml:space="preserve">
           <source>Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</source>
-          <target state="new">Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</target>
+          <target state="needs-review-translation">Beedrill is extremely territorial. No one should ever approach its nest—this is for their own safety. If angered, they will attack in a furious swarm.</target>
         </trans-unit>
         <trans-unit id="Pidgey.Description" translate="yes" xml:space="preserve">
           <source>Pidgey has an extremely sharp sense of direction. It is capable of unerringly returning home to its nest, however far it may be removed from its familiar surroundings.</source>
-          <target state="new">Pidgey has an extremely sharp sense of direction. It is capable of unerringly returning home to its nest, however far it may be removed from its familiar surroundings.</target>
+          <target state="final">Pidgey har en svært god retningssans. Den kan alltid huske veien hjem til reiret, uansett hvor langt unna den er.</target>
         </trans-unit>
         <trans-unit id="Pidgeotto.Description" translate="yes" xml:space="preserve">
           <source>Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</source>
-          <target state="new">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
+          <target state="needs-review-translation">Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</target>
         </trans-unit>
         <trans-unit id="Pidgeot.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</source>
-          <target state="new">This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</target>
+          <target state="needs-review-translation">This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</target>
         </trans-unit>
         <trans-unit id="Rattata.Description" translate="yes" xml:space="preserve">
           <source>Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</source>
-          <target state="new">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
+          <target state="needs-review-translation">Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</target>
         </trans-unit>
         <trans-unit id="Raticate.Description" translate="yes" xml:space="preserve">
           <source>Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</source>
-          <target state="new">Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</target>
+          <target state="needs-review-translation">Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</target>
         </trans-unit>
         <trans-unit id="Spearow.Description" translate="yes" xml:space="preserve">
           <source>Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</source>
-          <target state="new">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
+          <target state="needs-review-translation">Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</target>
         </trans-unit>
         <trans-unit id="Fearow.Description" translate="yes" xml:space="preserve">
           <source>Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</source>
-          <target state="new">Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</target>
+          <target state="needs-review-translation">Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</target>
         </trans-unit>
         <trans-unit id="Ekans.Description" translate="yes" xml:space="preserve">
           <source>Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</source>
-          <target state="new">Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</target>
+          <target state="needs-review-translation">Ekans curls itself up in a spiral while it rests. Assuming this position allows it to quickly respond to a threat from any direction with a glare from its upraised head.</target>
         </trans-unit>
         <trans-unit id="Arbok.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</source>
-          <target state="new">This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</target>
+          <target state="needs-review-translation">This Pokémon is terrifically strong in order to constrict things with its body. It can even flatten steel oil drums. Once Arbok wraps its body around its foe, escaping its crunching embrace is impossible.</target>
         </trans-unit>
         <trans-unit id="Pikachu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</source>
-          <target state="new">This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</target>
+          <target state="needs-review-translation">This Pokémon has electricity-storing pouches on its cheeks. These appear to become electrically charged during the night while Pikachu sleeps. It occasionally discharges electricity when it is dozy after waking up.</target>
         </trans-unit>
         <trans-unit id="Raichu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</source>
-          <target state="new">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
+          <target state="translated">This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</target>
         </trans-unit>
         <trans-unit id="Sandshrew.Description" translate="yes" xml:space="preserve">
           <source>Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</source>
-          <target state="new">Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</target>
+          <target state="needs-review-translation">Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</target>
         </trans-unit>
         <trans-unit id="Sandslash.Description" translate="yes" xml:space="preserve">
           <source>Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</source>
-          <target state="new">Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</target>
+          <target state="needs-review-translation">Sandslash can roll up its body as if it were a ball covered with large spikes. In battle, this Pokémon will try to make the foe flinch by jabbing it with its spines. It then leaps at the stunned foe to tear wildly with its sharp claws.</target>
         </trans-unit>
         <trans-unit id="NidoranFemale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</source>
-          <target state="new">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
+          <target state="needs-review-translation">Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</target>
         </trans-unit>
         <trans-unit id="Nidorina.Description" translate="yes" xml:space="preserve">
           <source>When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</source>
-          <target state="new">When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</target>
+          <target state="needs-review-translation">When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</target>
         </trans-unit>
         <trans-unit id="Nidoqueen.Description" translate="yes" xml:space="preserve">
           <source>Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</source>
-          <target state="new">Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</target>
+          <target state="needs-review-translation">Nidoqueen’s body is encased in extremely hard scales. It is adept at sending foes flying with harsh tackles. This Pokémon is at its strongest when it is defending its young.</target>
         </trans-unit>
         <trans-unit id="NidoranMale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</source>
-          <target state="new">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
+          <target state="needs-review-translation">Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</target>
         </trans-unit>
         <trans-unit id="Nidorino.Description" translate="yes" xml:space="preserve">
           <source>Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</source>
-          <target state="new">Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</target>
+          <target state="needs-review-translation">Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</target>
         </trans-unit>
         <trans-unit id="Nidoking.Description" translate="yes" xml:space="preserve">
           <source>Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</source>
-          <target state="new">Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</target>
+          <target state="needs-review-translation">Nidoking’s thick tail packs enormously destructive power. With one swing, it can topple a metal transmission tower. Once this Pokémon goes on a rampage, there is no stopping it.</target>
         </trans-unit>
         <trans-unit id="Clefairy.Description" translate="yes" xml:space="preserve">
           <source>On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</source>
-          <target state="new">On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</target>
+          <target state="needs-review-translation">On every night of a full moon, groups of this Pokémon come out to play. When dawn arrives, the tired Clefairy return to their quiet mountain retreats and go to sleep nestled up against each other.</target>
         </trans-unit>
         <trans-unit id="Clefable.Description" translate="yes" xml:space="preserve">
           <source>Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</source>
-          <target state="new">Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</target>
+          <target state="needs-review-translation">Clefable moves by skipping lightly as if it were flying using its wings. Its bouncy step lets it even walk on water. It is known to take strolls on lakes on quiet, moonlit nights.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="new">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
+          <target state="translated">Elektrisk-type</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>
-          <target state="new">Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</target>
+          <target state="needs-review-translation">Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</target>
         </trans-unit>
         <trans-unit id="Jigglypuff.Description" translate="yes" xml:space="preserve">
           <source>When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</source>
-          <target state="new">When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</target>
+          <target state="needs-review-translation">When this Pokémon sings, it never pauses to breathe. If it is in a battle against an opponent that does not easily fall asleep, Jigglypuff cannot breathe, endangering its life.</target>
         </trans-unit>
         <trans-unit id="Wigglytuff.Description" translate="yes" xml:space="preserve">
           <source>Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</source>
-          <target state="new">Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</target>
+          <target state="needs-review-translation">Wigglytuff’s body is very flexible. By inhaling deeply, this Pokémon can inflate itself seemingly without end. Once inflated, Wigglytuff bounces along lightly like a balloon.</target>
         </trans-unit>
         <trans-unit id="Zubat.Description" translate="yes" xml:space="preserve">
           <source>Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</source>
-          <target state="new">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
+          <target state="needs-review-translation">Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</target>
         </trans-unit>
         <trans-unit id="Golbat.Description" translate="yes" xml:space="preserve">
           <source>Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</source>
-          <target state="new">Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</target>
+          <target state="needs-review-translation">Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</target>
         </trans-unit>
         <trans-unit id="Oddish.Description" translate="yes" xml:space="preserve">
           <source>Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</source>
-          <target state="new">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
+          <target state="needs-review-translation">Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</target>
         </trans-unit>
         <trans-unit id="Gloom.Description" translate="yes" xml:space="preserve">
           <source>From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</source>
-          <target state="new">From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</target>
+          <target state="needs-review-translation">From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</target>
         </trans-unit>
         <trans-unit id="Vileplume.Description" translate="yes" xml:space="preserve">
           <source>Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</source>
-          <target state="new">Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</target>
+          <target state="needs-review-translation">Vileplume has the world’s largest petals. They are used to attract prey that are then doused with toxic spores. Once the prey are immobilized, this Pokémon catches and devours them.</target>
         </trans-unit>
         <trans-unit id="Paras.Description" translate="yes" xml:space="preserve">
           <source>Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</source>
-          <target state="new">Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</target>
+          <target state="needs-review-translation">Paras has parasitic mushrooms growing on its back called tochukaso. They grow large by drawing nutrients from this Bug Pokémon host. They are highly valued as a medicine for extending life.</target>
         </trans-unit>
         <trans-unit id="Parasect.Description" translate="yes" xml:space="preserve">
           <source>Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</source>
-          <target state="new">Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</target>
+          <target state="needs-review-translation">Parasect is known to infest large trees en masse and drain nutrients from the lower trunk and roots. When an infested tree dies, they move onto another tree all at once.</target>
         </trans-unit>
         <trans-unit id="Venonat.Description" translate="yes" xml:space="preserve">
           <source>Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</source>
-          <target state="new">Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</target>
+          <target state="needs-review-translation">Venonat is said to have evolved with a coat of thin, stiff hair that covers its entire body for protection. It possesses large eyes that never fail to spot even minuscule prey.</target>
         </trans-unit>
         <trans-unit id="Venomoth.Description" translate="yes" xml:space="preserve">
           <source>Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</source>
-          <target state="new">Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</target>
+          <target state="needs-review-translation">Venomoth is nocturnal—it is a Pokémon that only becomes active at night. Its favorite prey are small insects that gather around streetlights, attracted by the light in the darkness.</target>
         </trans-unit>
         <trans-unit id="Diglett.Description" translate="yes" xml:space="preserve">
           <source>Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</source>
-          <target state="new">Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</target>
+          <target state="needs-review-translation">Diglett are raised in most farms. The reason is simple— wherever this Pokémon burrows, the soil is left perfectly tilled for planting crops. This soil is made ideal for growing delicious vegetables.</target>
         </trans-unit>
         <trans-unit id="Dugtrio.Description" translate="yes" xml:space="preserve">
           <source>Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</source>
-          <target state="new">Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</target>
+          <target state="needs-review-translation">Dugtrio are actually triplets that emerged from one body. As a result, each triplet thinks exactly like the other two triplets. They work cooperatively to burrow endlessly.</target>
         </trans-unit>
         <trans-unit id="Meowth.Description" translate="yes" xml:space="preserve">
           <source>Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</source>
-          <target state="new">Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</target>
+          <target state="needs-review-translation">Meowth withdraws its sharp claws into its paws to slinkily sneak about without making any incriminating footsteps. For some reason, this Pokémon loves shiny coins that glitter with light.</target>
         </trans-unit>
         <trans-unit id="Persian.Description" translate="yes" xml:space="preserve">
           <source>Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</source>
-          <target state="new">Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</target>
+          <target state="needs-review-translation">Persian has six bold whiskers that give it a look of toughness. The whiskers sense air movements to determine what is in the Pokémon’s surrounding vicinity. It becomes docile if grabbed by the whiskers.</target>
         </trans-unit>
         <trans-unit id="Psyduck.Description" translate="yes" xml:space="preserve">
           <source>If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</source>
-          <target state="new">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
+          <target state="translated">If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</target>
         </trans-unit>
         <trans-unit id="Golduck.Description" translate="yes" xml:space="preserve">
           <source>Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</source>
-          <target state="new">Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</target>
+          <target state="needs-review-translation">Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</target>
         </trans-unit>
         <trans-unit id="Mankey.Description" translate="yes" xml:space="preserve">
           <source>When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</source>
-          <target state="new">When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</target>
+          <target state="needs-review-translation">When Mankey starts shaking and its nasal breathing turns rough, it’s a sure sign that it is becoming angry. However, because it goes into a towering rage almost instantly, it is impossible for anyone to flee its wrath.</target>
         </trans-unit>
         <trans-unit id="Primeape.Description" translate="yes" xml:space="preserve">
           <source>When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</source>
-          <target state="new">When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</target>
+          <target state="needs-review-translation">When Primeape becomes furious, its blood circulation is boosted. In turn, its muscles are made even stronger. However, it also becomes much less intelligent at the same time.</target>
         </trans-unit>
         <trans-unit id="Growlithe.Description" translate="yes" xml:space="preserve">
           <source>Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</source>
-          <target state="new">Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</target>
+          <target state="needs-review-translation">Growlithe has a superb sense of smell. Once it smells anything, this Pokémon won’t forget the scent, no matter what. It uses its advanced olfactory sense to determine the emotions of other living things.</target>
         </trans-unit>
         <trans-unit id="Arcanine.Description" translate="yes" xml:space="preserve">
           <source>Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</source>
-          <target state="new">Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</target>
+          <target state="needs-review-translation">Arcanine is known for its high speed. It is said to be capable of running over 6,200 miles in a single day and night. The fire that blazes wildly within this Pokémon’s body is its source of power.</target>
         </trans-unit>
         <trans-unit id="Poliwag.Description" translate="yes" xml:space="preserve">
           <source>Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</source>
-          <target state="new">Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</target>
+          <target state="needs-review-translation">Poliwag has a very thin skin. It is possible to see the Pokémon’s spiral innards right through the skin. Despite its thinness, however, the skin is also very flexible. Even sharp fangs bounce right off it.</target>
         </trans-unit>
         <trans-unit id="Poliwhirl.Description" translate="yes" xml:space="preserve">
           <source>The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</source>
-          <target state="new">The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</target>
+          <target state="needs-review-translation">The surface of Poliwhirl’s body is always wet and slick with a slimy fluid. Because of this slippery covering, it can easily slip and slide out of the clutches of any enemy in battle.</target>
         </trans-unit>
         <trans-unit id="Poliwrath.Description" translate="yes" xml:space="preserve">
           <source>Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</source>
-          <target state="new">Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</target>
+          <target state="needs-review-translation">Poliwrath’s highly developed, brawny muscles never grow fatigued, however much it exercises. It is so tirelessly strong, this Pokémon can swim back and forth across the ocean without effort.</target>
         </trans-unit>
         <trans-unit id="Abra.Description" translate="yes" xml:space="preserve">
           <source>Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</source>
-          <target state="new">Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</target>
+          <target state="needs-review-translation">Abra needs to sleep for eighteen hours a day. If it doesn’t, this Pokémon loses its ability to use telekinetic powers. If it is attacked, Abra escapes using Teleport while it is still sleeping.</target>
         </trans-unit>
         <trans-unit id="Kadabra.Description" translate="yes" xml:space="preserve">
           <source>Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</source>
-          <target state="new">Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</target>
+          <target state="needs-review-translation">Kadabra holds a silver spoon in its hand. The spoon is used to amplify the alpha waves in its brain. Without the spoon, the Pokémon is said to be limited to half the usual amount of its telekinetic powers.</target>
         </trans-unit>
         <trans-unit id="Alakazam.Description" translate="yes" xml:space="preserve">
           <source>Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</source>
-          <target state="new">Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</target>
+          <target state="needs-review-translation">Alakazam’s brain continually grows, infinitely multiplying brain cells. This amazing brain gives this Pokémon an astoundingly high IQ of 5,000. It has a thorough memory of everything that has occurred in the world.</target>
         </trans-unit>
         <trans-unit id="Machop.Description" translate="yes" xml:space="preserve">
           <source>Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</source>
-          <target state="new">Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</target>
+          <target state="needs-review-translation">Machop exercises by hefting around a Graveler as if it were a barbell. There are some Machop that travel the world in a quest to master all kinds of martial arts.</target>
         </trans-unit>
         <trans-unit id="Machoke.Description" translate="yes" xml:space="preserve">
           <source>Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</source>
-          <target state="new">Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</target>
+          <target state="needs-review-translation">Machoke undertakes bodybuilding every day even as it helps people with tough, physically demanding labor. On its days off, this Pokémon heads to the fields and mountains to exercise and train.</target>
         </trans-unit>
         <trans-unit id="Machamp.Description" translate="yes" xml:space="preserve">
           <source>Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</source>
-          <target state="new">Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</target>
+          <target state="needs-review-translation">Machamp is known as the Pokémon that has mastered every kind of martial arts. If it grabs hold of the foe with its four arms, the battle is all but over. The hapless foe is thrown far over the horizon.</target>
         </trans-unit>
         <trans-unit id="Bellsprout.Description" translate="yes" xml:space="preserve">
           <source>Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</source>
-          <target state="new">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
+          <target state="needs-review-translation">Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</target>
         </trans-unit>
         <trans-unit id="Weepinbell.Description" translate="yes" xml:space="preserve">
           <source>Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</source>
-          <target state="new">Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</target>
+          <target state="needs-review-translation">Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</target>
         </trans-unit>
         <trans-unit id="Victreebel.Description" translate="yes" xml:space="preserve">
           <source>Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</source>
-          <target state="new">Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</target>
+          <target state="needs-review-translation">Victreebel has a long vine that extends from its head. This vine is waved and flicked about as if it were an animal to attract prey. When an unsuspecting prey draws near, this Pokémon swallows it whole.</target>
         </trans-unit>
         <trans-unit id="Tentacool.Description" translate="yes" xml:space="preserve">
           <source>Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</source>
-          <target state="new">Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</target>
+          <target state="needs-review-translation">Tentacool absorbs sunlight and refracts it using water inside its body to convert it into beam energy. This Pokémon shoots beams from the small round organ above its eyes.</target>
         </trans-unit>
         <trans-unit id="Tentacruel.Description" translate="yes" xml:space="preserve">
           <source>Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</source>
-          <target state="new">Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</target>
+          <target state="needs-review-translation">Tentacruel has tentacles that can be freely elongated and shortened at will. It ensnares prey with its tentacles and weakens the prey by dosing it with a harsh toxin. It can catch up to 80 prey at the same time.</target>
         </trans-unit>
         <trans-unit id="Geodude.Description" translate="yes" xml:space="preserve">
           <source>When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</source>
-          <target state="new">When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</target>
+          <target state="needs-review-translation">When Geodude sleeps deeply, it buries itself halfway into the ground. It will not awaken even if hikers step on it unwittingly. In the morning, this Pokémon rolls downhill in search of food.</target>
         </trans-unit>
         <trans-unit id="Graveler.Description" translate="yes" xml:space="preserve">
           <source>Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</source>
-          <target state="new">Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</target>
+          <target state="needs-review-translation">Rocks are Graveler’s favorite food. This Pokémon will climb a mountain from the base to the summit, crunchingly feasting on rocks all the while. Upon reaching the peak, it rolls back down to the bottom.</target>
         </trans-unit>
         <trans-unit id="Golem.Description" translate="yes" xml:space="preserve">
           <source>Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</source>
-          <target state="new">Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</target>
+          <target state="needs-review-translation">Golem is known for rolling down from mountains. To prevent them from rolling into the homes of people downhill, grooves have been dug into the sides of mountains to serve as guideways for diverting this Pokémon’s course.</target>
         </trans-unit>
         <trans-unit id="Ponyta.Description" translate="yes" xml:space="preserve">
           <source>Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</source>
-          <target state="new">Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</target>
+          <target state="needs-review-translation">Ponyta is very weak at birth. It can barely stand up. This Pokémon becomes stronger by stumbling and falling to keep up with its parent.</target>
         </trans-unit>
         <trans-unit id="Rapidash.Description" translate="yes" xml:space="preserve">
           <source>Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</source>
-          <target state="new">Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</target>
+          <target state="needs-review-translation">Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph.</target>
         </trans-unit>
         <trans-unit id="Slowpoke.Description" translate="yes" xml:space="preserve">
           <source>Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</source>
-          <target state="new">Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</target>
+          <target state="needs-review-translation">Slowpoke uses its tail to catch prey by dipping it in water at the side of a river. However, this Pokémon often forgets what it’s doing and often spends entire days just loafing at water’s edge.</target>
         </trans-unit>
         <trans-unit id="Slowbro.Description" translate="yes" xml:space="preserve">
           <source>Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</source>
-          <target state="new">Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</target>
+          <target state="needs-review-translation">Slowbro’s tail has a Shellder firmly attached with a bite. As a result, the tail can’t be used for fishing anymore. This causes Slowbro to grudgingly swim and catch prey instead.</target>
         </trans-unit>
         <trans-unit id="Magnemite.Description" translate="yes" xml:space="preserve">
           <source>Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</source>
-          <target state="new">Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</target>
+          <target state="needs-review-translation">Magnemite floats in the air by emitting electromagnetic waves from the units at its sides. These waves block gravity. This Pokémon becomes incapable of flight if its internal electrical supply is depleted.</target>
         </trans-unit>
         <trans-unit id="Magneton.Description" translate="yes" xml:space="preserve">
           <source>Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</source>
-          <target state="new">Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</target>
+          <target state="needs-review-translation">Magneton emits a powerful magnetic force that is fatal to electronics and precision instruments. Because of this, it is said that some towns warn people to keep this Pokémon inside a Poké Ball.</target>
         </trans-unit>
         <trans-unit id="Farfetchd.Description" translate="yes" xml:space="preserve">
           <source>Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</source>
-          <target state="new">Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</target>
+          <target state="needs-review-translation">Farfetch’d is always seen with a stalk from a plant of some sort. Apparently, there are good stalks and bad stalks. This Pokémon has been known to fight with others over stalks.</target>
         </trans-unit>
         <trans-unit id="Doduo.Description" translate="yes" xml:space="preserve">
           <source>Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</source>
-          <target state="new">Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</target>
+          <target state="needs-review-translation">Doduo’s two heads contain completely identical brains. A scientific study reported that on rare occasions, there will be examples of this Pokémon possessing different sets of brains.</target>
         </trans-unit>
         <trans-unit id="Dodrio.Description" translate="yes" xml:space="preserve">
           <source>Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</source>
-          <target state="new">Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</target>
+          <target state="needs-review-translation">Apparently, the heads aren’t the only parts of the body that Dodrio has three of. It has three sets of hearts and lungs as well, so it is capable of running long distances without rest.</target>
         </trans-unit>
         <trans-unit id="Seel.Description" translate="yes" xml:space="preserve">
           <source>Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</source>
-          <target state="new">Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</target>
+          <target state="needs-review-translation">Seel hunts for prey in the frigid sea underneath sheets of ice. When it needs to breathe, it punches a hole through the ice with the sharply protruding section of its head.</target>
         </trans-unit>
         <trans-unit id="Dewgong.Description" translate="yes" xml:space="preserve">
           <source>Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</source>
-          <target state="new">Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</target>
+          <target state="needs-review-translation">Dewgong loves to snooze on bitterly cold ice. The sight of this Pokémon sleeping on a glacier was mistakenly thought to be a mermaid by a mariner long ago.</target>
         </trans-unit>
         <trans-unit id="Grimer.Description" translate="yes" xml:space="preserve">
           <source>Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</source>
-          <target state="new">Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</target>
+          <target state="needs-review-translation">Grimer emerged from the sludge that settled on a polluted seabed. This Pokémon loves anything filthy. It constantly leaks a horribly germ-infested fluid from all over its body.</target>
         </trans-unit>
         <trans-unit id="Muk.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</source>
-          <target state="new">This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</target>
+          <target state="needs-review-translation">This Pokémon’s favorite food is anything that is repugnantly filthy. In dirty towns where people think nothing of throwing away litter on the streets, Muk are certain to gather.</target>
         </trans-unit>
         <trans-unit id="Shellder.Description" translate="yes" xml:space="preserve">
           <source>At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</source>
-          <target state="new">At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</target>
+          <target state="needs-review-translation">At night, this Pokémon uses its broad tongue to burrow a hole in the seafloor sand and then sleep in it. While it is sleeping, Shellder closes its shell, but leaves its tongue hanging out.</target>
         </trans-unit>
         <trans-unit id="Cloyster.Description" translate="yes" xml:space="preserve">
           <source>Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</source>
-          <target state="new">Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</target>
+          <target state="needs-review-translation">Cloyster is capable of swimming in the sea. It does so by swallowing water, then jetting it out toward the rear. This Pokémon shoots spikes from its shell using the same system.</target>
         </trans-unit>
         <trans-unit id="Gastly.Description" translate="yes" xml:space="preserve">
           <source>Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</source>
-          <target state="new">Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</target>
+          <target state="needs-review-translation">Gastly is largely composed of gaseous matter. When exposed to a strong wind, the gaseous body quickly dwindles away. Groups of this Pokémon cluster under the eaves of houses to escape the ravages of wind.</target>
         </trans-unit>
         <trans-unit id="Haunter.Description" translate="yes" xml:space="preserve">
           <source>Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</source>
-          <target state="new">Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</target>
+          <target state="needs-review-translation">Haunter is a dangerous Pokémon. If one beckons you while floating in darkness, you must never approach it. This Pokémon will try to lick you with its tongue and steal your life away.</target>
         </trans-unit>
         <trans-unit id="Gengar.Description" translate="yes" xml:space="preserve">
           <source>Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</source>
-          <target state="new">Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</target>
+          <target state="needs-review-translation">Sometimes, on a dark night, your shadow thrown by a streetlight will suddenly and startlingly overtake you. It is actually a Gengar running past you, pretending to be your shadow.</target>
         </trans-unit>
         <trans-unit id="Onix.Description" translate="yes" xml:space="preserve">
           <source>Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</source>
-          <target state="new">Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</target>
+          <target state="needs-review-translation">Onix has a magnet in its brain. It acts as a compass so that this Pokémon does not lose direction while it is tunneling. As it grows older, its body becomes increasingly rounder and smoother.</target>
         </trans-unit>
         <trans-unit id="Drowzee.Description" translate="yes" xml:space="preserve">
           <source>If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</source>
-          <target state="new">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
+          <target state="needs-review-translation">If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</target>
         </trans-unit>
         <trans-unit id="Hypno.Description" translate="yes" xml:space="preserve">
           <source>Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</source>
-          <target state="new">Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</target>
+          <target state="needs-review-translation">Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</target>
         </trans-unit>
         <trans-unit id="Krabby.Description" translate="yes" xml:space="preserve">
           <source>Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</source>
-          <target state="new">Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</target>
+          <target state="needs-review-translation">Krabby live on beaches, burrowed inside holes dug into the sand. On sandy beaches with little in the way of food, these Pokémon can be seen squabbling with each other over territory.</target>
         </trans-unit>
         <trans-unit id="Kingler.Description" translate="yes" xml:space="preserve">
           <source>Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</source>
-          <target state="new">Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</target>
+          <target state="needs-review-translation">Kingler has an enormous, oversized claw. It waves this huge claw in the air to communicate with others. However, because the claw is so heavy, the Pokémon quickly tires.</target>
         </trans-unit>
         <trans-unit id="Voltorb.Description" translate="yes" xml:space="preserve">
           <source>Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</source>
-          <target state="new">Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</target>
+          <target state="needs-review-translation">Voltorb is extremely sensitive—it explodes at the slightest of shocks. It is rumored that it was first created when a Poké Ball was exposed to a powerful pulse of energy.</target>
         </trans-unit>
         <trans-unit id="Electrode.Description" translate="yes" xml:space="preserve">
           <source>One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</source>
-          <target state="new">One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</target>
+          <target state="needs-review-translation">One of Electrode’s characteristics is its attraction to electricity. It is a problematical Pokémon that congregates mostly at electrical power plants to feed on electricity that has just been generated.</target>
         </trans-unit>
         <trans-unit id="Exeggcute.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</source>
-          <target state="new">This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</target>
+          <target state="needs-review-translation">This Pokémon consists of six eggs that form a closely knit cluster. The six eggs attract each other and spin around. When cracks increasingly appear on the eggs, Exeggcute is close to evolution.</target>
         </trans-unit>
         <trans-unit id="Exeggutor.Description" translate="yes" xml:space="preserve">
           <source>Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</source>
-          <target state="new">Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</target>
+          <target state="needs-review-translation">Exeggutor originally came from the tropics. Its heads steadily grow larger from exposure to strong sunlight. It is said that when the heads fall off, they group together to form Exeggcute.</target>
         </trans-unit>
         <trans-unit id="Cubone.Description" translate="yes" xml:space="preserve">
           <source>Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</source>
-          <target state="new">Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</target>
+          <target state="needs-review-translation">Cubone pines for the mother it will never see again. Seeing a likeness of its mother in the full moon, it cries. The stains on the skull the Pokémon wears are made by the tears it sheds.</target>
         </trans-unit>
         <trans-unit id="Marowak.Description" translate="yes" xml:space="preserve">
           <source>Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</source>
-          <target state="new">Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</target>
+          <target state="needs-review-translation">Marowak is the evolved form of a Cubone that has overcome its sadness at the loss of its mother and grown tough. This Pokémon’s tempered and hardened spirit is not easily broken.</target>
         </trans-unit>
         <trans-unit id="Hitmonlee.Description" translate="yes" xml:space="preserve">
           <source>Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</source>
-          <target state="new">Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</target>
+          <target state="needs-review-translation">Hitmonlee’s legs freely contract and stretch. Using these springlike legs, it bowls over foes with devastating kicks. After battle, it rubs down its legs and loosens the muscles to overcome fatigue.</target>
         </trans-unit>
         <trans-unit id="Hitmonchan.Description" translate="yes" xml:space="preserve">
           <source>Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</source>
-          <target state="new">Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</target>
+          <target state="needs-review-translation">Hitmonchan is said to possess the spirit of a boxer who had been working toward a world championship. This Pokémon has an indomitable spirit and will never give up in the face of adversity.</target>
         </trans-unit>
         <trans-unit id="Lickitung.Description" translate="yes" xml:space="preserve">
           <source>Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</source>
-          <target state="new">Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</target>
+          <target state="needs-review-translation">Whenever Lickitung comes across something new, it will unfailingly give it a lick. It does so because it memorizes things by texture and by taste. It is somewhat put off by sour things.</target>
         </trans-unit>
         <trans-unit id="Koffing.Description" translate="yes" xml:space="preserve">
           <source>Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</source>
-          <target state="new">Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</target>
+          <target state="needs-review-translation">Koffing embodies toxic substances. It mixes the toxins with raw garbage to set off a chemical reaction that results in a terribly powerful poison gas. The higher the temperature, the more gas is concocted by this Pokémon.</target>
         </trans-unit>
         <trans-unit id="Weezing.Description" translate="yes" xml:space="preserve">
           <source>Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</source>
-          <target state="new">Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</target>
+          <target state="needs-review-translation">Weezing alternately shrinks and inflates its twin bodies to mix together toxic gases inside. The more the gases are mixed, the more powerful the toxins become. The Pokémon also becomes more putrid.</target>
         </trans-unit>
         <trans-unit id="Rhyhorn.Description" translate="yes" xml:space="preserve">
           <source>Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</source>
-          <target state="new">Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</target>
+          <target state="needs-review-translation">Rhyhorn’s brain is very small. It is so dense, while on a run it forgets why it started running in the first place. It apparently remembers sometimes if it demolishes something.</target>
         </trans-unit>
         <trans-unit id="Rhydon.Description" translate="yes" xml:space="preserve">
           <source>Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</source>
-          <target state="new">Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</target>
+          <target state="needs-review-translation">Rhydon has a horn that serves as a drill. It is used for destroying rocks and boulders. This Pokémon occasionally rams into streams of magma, but the armor-like hide prevents it from feeling the heat.</target>
         </trans-unit>
         <trans-unit id="Chansey.Description" translate="yes" xml:space="preserve">
           <source>Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</source>
-          <target state="new">Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</target>
+          <target state="needs-review-translation">Chansey lays nutritionally excellent eggs on an everyday basis. The eggs are so delicious, they are easily and eagerly devoured by even those people who have lost their appetite.</target>
         </trans-unit>
         <trans-unit id="Tangela.Description" translate="yes" xml:space="preserve">
           <source>Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</source>
-          <target state="new">Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</target>
+          <target state="needs-review-translation">Tangela’s vines snap off easily if they are grabbed. This happens without pain, allowing it to make a quick getaway. The lost vines are replaced by newly grown vines the very next day.</target>
         </trans-unit>
         <trans-unit id="Kangaskhan.Description" translate="yes" xml:space="preserve">
           <source>If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</source>
-          <target state="new">If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</target>
+          <target state="needs-review-translation">If you come across a young Kangaskhan playing by itself, you must never disturb it or attempt to catch it. The baby Pokémon’s parent is sure to be in the area, and it will become violently enraged at you.</target>
         </trans-unit>
         <trans-unit id="Horsea.Description" translate="yes" xml:space="preserve">
           <source>If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</source>
-          <target state="new">If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</target>
+          <target state="needs-review-translation">If Horsea senses danger, it will reflexively spray a dense black ink from its mouth and try to escape. This Pokémon swims by cleverly flapping the fin on its back.</target>
         </trans-unit>
         <trans-unit id="Seadra.Description" translate="yes" xml:space="preserve">
           <source>Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</source>
-          <target state="new">Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</target>
+          <target state="needs-review-translation">Seadra generates whirlpools by spinning its body. The whirlpools are strong enough to swallow even fishing boats. This Pokémon weakens prey with these currents, then swallows it whole.</target>
         </trans-unit>
         <trans-unit id="Goldeen.Description" translate="yes" xml:space="preserve">
           <source>Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</source>
-          <target state="new">Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</target>
+          <target state="needs-review-translation">Goldeen loves swimming wild and free in rivers and ponds. If one of these Pokémon is placed in an aquarium, it will shatter even the thickest glass with one ram of its horn and make its escape.</target>
         </trans-unit>
         <trans-unit id="Seaking.Description" translate="yes" xml:space="preserve">
           <source>Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</source>
-          <target state="new">Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</target>
+          <target state="needs-review-translation">Seaking is very protective of its eggs. The male and female will take turns patrolling around their nest and eggs. The guarding of eggs by these Pokémon goes on for over a month.</target>
         </trans-unit>
         <trans-unit id="Staryu.Description" translate="yes" xml:space="preserve">
           <source>Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</source>
-          <target state="new">Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</target>
+          <target state="needs-review-translation">Staryu apparently communicates with the stars in the night sky by flashing the red core at the center of its body. If parts of its body are torn, this Pokémon simply regenerates the missing pieces and limbs.</target>
         </trans-unit>
         <trans-unit id="Starmie.Description" translate="yes" xml:space="preserve">
           <source>Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</source>
-          <target state="new">Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</target>
+          <target state="needs-review-translation">Starmie swims through water by spinning its star-shaped body as if it were a propeller on a ship. The core at the center of this Pokémon’s body glows in seven colors.</target>
         </trans-unit>
         <trans-unit id="MrMime.Description" translate="yes" xml:space="preserve">
           <source>Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</source>
-          <target state="new">Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</target>
+          <target state="needs-review-translation">Mr. Mime is a master of pantomime. Its gestures and motions convince watchers that something unseeable actually exists. Once the watchers are convinced, the unseeable thing exists as if it were real.</target>
         </trans-unit>
         <trans-unit id="Scyther.Description" translate="yes" xml:space="preserve">
           <source>Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</source>
-          <target state="new">Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</target>
+          <target state="needs-review-translation">Scyther is blindingly fast. Its blazing speed enhances the effectiveness of the twin scythes on its forearms. This Pokémon’s scythes are so effective, they can slice through thick logs in one wicked stroke.</target>
         </trans-unit>
         <trans-unit id="Jynx.Description" translate="yes" xml:space="preserve">
           <source>Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</source>
-          <target state="new">Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</target>
+          <target state="needs-review-translation">Jynx walks rhythmically, swaying and shaking its hips as if it were dancing. Its motions are so bouncingly alluring, people seeing it are compelled to shake their hips without giving any thought to what they are doing.</target>
         </trans-unit>
         <trans-unit id="Electabuzz.Description" translate="yes" xml:space="preserve">
           <source>When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</source>
-          <target state="new">When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</target>
+          <target state="needs-review-translation">When a storm arrives, gangs of this Pokémon compete with each other to scale heights that are likely to be stricken by lightning bolts. Some towns use Electabuzz in place of lightning rods.</target>
         </trans-unit>
         <trans-unit id="Magmar.Description" translate="yes" xml:space="preserve">
           <source>In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</source>
-          <target state="new">In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</target>
+          <target state="needs-review-translation">In battle, Magmar blows out intensely hot flames from all over its body to intimidate its opponent. This Pokémon’s fiery bursts create heat waves that ignite grass and trees in its surroundings.</target>
         </trans-unit>
         <trans-unit id="Pinsir.Description" translate="yes" xml:space="preserve">
           <source>Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</source>
-          <target state="new">Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</target>
+          <target state="needs-review-translation">Pinsir has a pair of massive horns. Protruding from the surface of these horns are thorns. These thorns are driven deeply into the foe’s body when the pincer closes, making it tough for the foe to escape.</target>
         </trans-unit>
         <trans-unit id="Tauros.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</source>
-          <target state="new">This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</target>
+          <target state="needs-review-translation">This Pokémon is not satisfied unless it is rampaging at all times. If there is no opponent for Tauros to battle, it will charge at thick trees and knock them down to calm itself.</target>
         </trans-unit>
         <trans-unit id="Magikarp.Description" translate="yes" xml:space="preserve">
           <source>Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</source>
-          <target state="new">Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</target>
+          <target state="needs-review-translation">Magikarp is virtually useless in battle as it can only splash around. As a result, it is considered to be weak. However, it is actually a very hardy Pokémon that can survive in any body of water no matter how polluted it is.</target>
         </trans-unit>
         <trans-unit id="Gyarados.Description" translate="yes" xml:space="preserve">
           <source>Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</source>
-          <target state="new">Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</target>
+          <target state="needs-review-translation">Once Gyarados goes on a rampage, its ferociously violent blood doesn’t calm until it has burned everything down. There are records of this Pokémon’s rampages lasting a whole month.</target>
         </trans-unit>
         <trans-unit id="Lapras.Description" translate="yes" xml:space="preserve">
           <source>People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</source>
-          <target state="new">People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</target>
+          <target state="needs-review-translation">People have driven Lapras almost to the point of extinction. In the evenings, this Pokémon is said to sing plaintively as it seeks what few others of its kind still remain.</target>
         </trans-unit>
         <trans-unit id="Ditto.Description" translate="yes" xml:space="preserve">
           <source>Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</source>
-          <target state="new">Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</target>
+          <target state="needs-review-translation">Ditto rearranges its cell structure to transform itself into other shapes. However, if it tries to transform itself into something by relying on its memory, this Pokémon manages to get details wrong.</target>
         </trans-unit>
         <trans-unit id="Eevee.Description" translate="yes" xml:space="preserve">
           <source>Eevee has an unstable genetic makeup that suddenly mutates due to the environment in which it lives. Radiation from various stones causes this Pokémon to evolve.</source>
-          <target state="new">Eevee has an unstable genetic makeup that suddenly mutates due to the environment in which it lives. Radiation from various stones causes this Pokémon to evolve.</target>
+          <target state="final">Eevee har svært ustabile gener som gjør at den kan muteres. Mutasjonen kommer ann på miljøet den lever i. Stråling fra ulike steiner kan føre denne Pokémonen til å utvikle seg.</target>
         </trans-unit>
         <trans-unit id="Vaporeon.Description" translate="yes" xml:space="preserve">
           <source>Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</source>
-          <target state="new">Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</target>
+          <target state="needs-review-translation">Vaporeon underwent a spontaneous mutation and grew fins and gills that allow it to live underwater. This Pokémon has the ability to freely control water.</target>
         </trans-unit>
         <trans-unit id="Jolteon.Description" translate="yes" xml:space="preserve">
           <source>Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</source>
-          <target state="new">Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</target>
+          <target state="needs-review-translation">Jolteon’s cells generate a low level of electricity. This power is amplified by the static electricity of its fur, enabling the Pokémon to drop thunderbolts. The bristling fur is made of electrically charged needles.</target>
         </trans-unit>
         <trans-unit id="Flareon.Description" translate="yes" xml:space="preserve">
           <source>Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</source>
-          <target state="new">Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</target>
+          <target state="needs-review-translation">Flareon’s fluffy fur has a functional purpose—it releases heat into the air so that its body does not get excessively hot. This Pokémon’s body temperature can rise to a maximum of 1,650 degrees Fahrenheit.</target>
         </trans-unit>
         <trans-unit id="Porygon.Description" translate="yes" xml:space="preserve">
           <source>Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</source>
-          <target state="new">Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</target>
+          <target state="needs-review-translation">Porygon is capable of reverting itself entirely back to program data and entering cyberspace. This Pokémon is copy protected so it cannot be duplicated by copying.</target>
         </trans-unit>
         <trans-unit id="Omanyte.Description" translate="yes" xml:space="preserve">
           <source>Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</source>
-          <target state="new">Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</target>
+          <target state="needs-review-translation">Omanyte is one of the ancient and long-since-extinct Pokémon that have been regenerated from fossils by people. If attacked by an enemy, it withdraws itself inside its hard shell.</target>
         </trans-unit>
         <trans-unit id="Omastar.Description" translate="yes" xml:space="preserve">
           <source>Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</source>
-          <target state="new">Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</target>
+          <target state="needs-review-translation">Omastar uses its tentacles to capture its prey. It is believed to have become extinct because its shell grew too large and heavy, causing its movements to become too slow and ponderous.</target>
         </trans-unit>
         <trans-unit id="Kabuto.Description" translate="yes" xml:space="preserve">
           <source>Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</source>
-          <target state="new">Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</target>
+          <target state="needs-review-translation">Kabuto is a Pokémon that has been regenerated from a fossil. However, in extremely rare cases, living examples have been discovered. The Pokémon has not changed at all for 300 million years.</target>
         </trans-unit>
         <trans-unit id="Kabutops.Description" translate="yes" xml:space="preserve">
           <source>Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</source>
-          <target state="new">Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</target>
+          <target state="needs-review-translation">Kabutops swam underwater to hunt for its prey in ancient times. The Pokémon was apparently evolving from being a water dweller to living on land as evident from the beginnings of change in its gills and legs.</target>
         </trans-unit>
         <trans-unit id="Aerodactyl.Description" translate="yes" xml:space="preserve">
           <source>Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</source>
-          <target state="new">Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</target>
+          <target state="needs-review-translation">Aerodactyl is a Pokémon from the age of dinosaurs. It was regenerated from genetic material extracted from amber. It is imagined to have been the king of the skies in ancient times.</target>
         </trans-unit>
         <trans-unit id="Snorlax.Description" translate="yes" xml:space="preserve">
           <source>Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</source>
-          <target state="new">Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</target>
+          <target state="needs-review-translation">Snorlax’s typical day consists of nothing more than eating and sleeping. It is such a docile Pokémon that there are children who use its expansive belly as a place to play.</target>
         </trans-unit>
         <trans-unit id="Articuno.Description" translate="yes" xml:space="preserve">
           <source>Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</source>
-          <target state="new">Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</target>
+          <target state="needs-review-translation">Articuno is a legendary bird Pokémon that can control ice. The flapping of its wings chills the air. As a result, it is said that when this Pokémon flies, snow will fall.</target>
         </trans-unit>
         <trans-unit id="Zapdos.Description" translate="yes" xml:space="preserve">
           <source>Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</source>
-          <target state="new">Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</target>
+          <target state="needs-review-translation">Zapdos is a legendary bird Pokémon that has the ability to control electricity. It usually lives in thunderclouds. The Pokémon gains power if it is stricken by lightning bolts.</target>
         </trans-unit>
         <trans-unit id="Moltres.Description" translate="yes" xml:space="preserve">
           <source>Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</source>
-          <target state="new">Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</target>
+          <target state="needs-review-translation">Moltres is a legendary bird Pokémon that has the ability to control fire. If this Pokémon is injured, it is said to dip its body in the molten magma of a volcano to burn and heal itself.</target>
         </trans-unit>
         <trans-unit id="Dratini.Description" translate="yes" xml:space="preserve">
           <source>Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</source>
-          <target state="new">Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</target>
+          <target state="needs-review-translation">Dratini continually molts and sloughs off its old skin. It does so because the life energy within its body steadily builds to reach uncontrollable levels.</target>
         </trans-unit>
         <trans-unit id="Dragonair.Description" translate="yes" xml:space="preserve">
           <source>Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</source>
-          <target state="new">Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</target>
+          <target state="needs-review-translation">Dragonair stores an enormous amount of energy inside its body. It is said to alter weather conditions in its vicinity by discharging energy from the crystals on its neck and tail.</target>
         </trans-unit>
         <trans-unit id="Dragonite.Description" translate="yes" xml:space="preserve">
           <source>Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</source>
-          <target state="new">Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</target>
+          <target state="needs-review-translation">Dragonite is capable of circling the globe in just 16 hours. It is a kindhearted Pokémon that leads lost and foundering ships in a storm to the safety of land.</target>
         </trans-unit>
         <trans-unit id="Mewtwo.Description" translate="yes" xml:space="preserve">
           <source>Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</source>
-          <target state="new">Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</target>
+          <target state="needs-review-translation">Mewtwo is a Pokémon that was created by genetic manipulation. However, even though the scientific power of humans created this Pokémon’s body, they failed to endow Mewtwo with a compassionate heart.</target>
         </trans-unit>
         <trans-unit id="Mew.Description" translate="yes" xml:space="preserve">
           <source>Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</source>
-          <target state="new">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
+          <target state="translated">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
         </trans-unit>
       </group>
     </body>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
@@ -390,7 +390,7 @@
         </trans-unit>
         <trans-unit id="NumberTextBlock.Text" translate="yes" xml:space="preserve">
           <source>+ </source>
-          <target state="needs-review-translation"># </target>
+          <target state="needs-review-translation">+ </target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
           <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the +</note>
         </trans-unit>
@@ -1090,11 +1090,11 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="PokemonEncounterErrorText" translate="yes" xml:space="preserve">
           <source>There was an error loading the encounter with {0}, please try again later.</source>
-          <target state="new">There was an error loading the encounter with {0}, please try again later.</target>
+          <target state="new">Det oppstod en feil under lasting av møtet med {0}, prøv igjen senere.</target>
         </trans-unit>
         <trans-unit id="PokemonEncounterNotInRangeText" translate="yes" xml:space="preserve">
           <source>{0} is not in catch range anymore.</source>
-          <target state="new">{0} is not in catch range anymore.</target>
+          <target state="new">{0} er ikke i område lenger.</target>
         </trans-unit>
       </group>
     </body>
@@ -2597,7 +2597,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="translated">Elektrisk-type</target>
+          <target state="translated">Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>

--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.nn-NO.xlf
@@ -391,6 +391,7 @@
         <trans-unit id="NumberTextBlock.Text" translate="yes" xml:space="preserve">
           <source>+ </source>
           <target state="needs-review-translation">+ </target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
           <note from="MultilingualBuild" annotates="source" priority="2">Watch out: there is a space after the +</note>
         </trans-unit>
         <trans-unit id="SlashSpaceCpTextBlock.Text" translate="yes" xml:space="preserve">
@@ -1094,6 +1095,10 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         <trans-unit id="PokemonEncounterNotInRangeText" translate="yes" xml:space="preserve">
           <source>{0} is not in catch range anymore.</source>
           <target state="new">{0} er ikke i område lenger.</target>
+        </trans-unit>
+        <trans-unit id="CannotTransferFavorite" translate="yes" xml:space="preserve">
+          <source>Cannot transfer a favorite Pokémon!</source>
+          <target state="new">Du kan ikke overføre en favoritt Pokémon!</target>
         </trans-unit>
       </group>
     </body>
@@ -2464,7 +2469,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Charmander.Description" translate="yes" xml:space="preserve">
           <source>The flame that burns at the tip of its tail is an indication of its emotions. The flame wavers when Charmander is enjoying itself. If the Pokémon becomes enraged, the flame burns fiercely.</source>
-          <target state="translated">Flammen som brenner på tuppen av halen er en indikasjon på Pokémonen sine følelser. Flammen lager bølger når Charmander koser seg. Hvis Pokémonen blir rasende brenner flammen voldsomt.</target>
+          <target state="final">Flammen som brenner på tuppen av halen er en indikasjon på Pokémonen sine følelser. Flammen lager bølger når Charmander koser seg. Hvis Pokémonen blir rasende brenner flammen voldsomt.</target>
         </trans-unit>
         <trans-unit id="Charmeleon.Description" translate="yes" xml:space="preserve">
           <source>Charmeleon mercilessly destroys its foes using its sharp claws. If it encounters a strong foe, it turns aggressive. In this excited state, the flame at the tip of its tail flares with a bluish white color.</source>
@@ -2476,7 +2481,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Squirtle.Description" translate="yes" xml:space="preserve">
           <source>Squirtle’s shell is not merely used for protection. The shell’s rounded shape and the grooves on its surface help minimize resistance in water, enabling this Pokémon to swim at high speeds.</source>
-          <target state="translated">Squirtle sitt skall er ikke bare brukt for beskyttelse. Skallet har en avrundet form og riller på overflaten som reduserer motstand i vann, slik at Pokémonen kan svømme i høye hastigheter.</target>
+          <target state="final">Squirtle sitt skall er ikke bare brukt for beskyttelse. Skallet har en avrundet form og riller på overflaten som reduserer motstand i vann, slik at Pokémonen kan svømme i høye hastigheter.</target>
         </trans-unit>
         <trans-unit id="Wartortle.Description" translate="yes" xml:space="preserve">
           <source>Its tail is large and covered with a rich, thick fur. The tail becomes increasingly deeper in color as Wartortle ages. The scratches on its shell are evidence of this Pokémon’s toughness as a battler.</source>
@@ -2488,11 +2493,11 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Caterpie.Description" translate="yes" xml:space="preserve">
           <source>Caterpie has a voracious appetite. It can devour leaves bigger than its body right before your eyes. From its antenna, this Pokémon releases a terrifically strong odor.</source>
-          <target state="translated">Caterpie har en glupsk appetitt. Den kan sluke blader større enn kroppen sin rett foran øynene dine. Fra antenene sender den ut en forferdelig sterk lukt. </target>
+          <target state="final">Caterpie har en glupsk appetitt. Den kan sluke blader større enn kroppen sin rett foran øynene dine. Fra antenene sender den ut en forferdelig sterk lukt. </target>
         </trans-unit>
         <trans-unit id="Metapod.Description" translate="yes" xml:space="preserve">
           <source>The shell covering this Pokémon’s body is as hard as an iron slab. Metapod does not move very much. It stays still because it is preparing its soft innards for evolution inside the hard shell.</source>
-          <target state="translated">Skallet som dekker Pokémonen sin kropp er like hard som jern. Metapod flytte ikke mye. Det ligger stille fordi det forbereder utviklingen sin innenfor det harde skallet.</target>
+          <target state="final">Skallet som dekker Pokémonen sin kropp er like hard som jern. Metapod flytte ikke mye. Det ligger stille fordi det forbereder utviklingen sin innenfor det harde skallet.</target>
         </trans-unit>
         <trans-unit id="Butterfree.Description" translate="yes" xml:space="preserve">
           <source>Butterfree has a superior ability to search for delicious honey from flowers. It can even search out, extract, and carry honey from flowers that are blooming over six miles from its nest.</source>
@@ -2500,7 +2505,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Weedle.Description" translate="yes" xml:space="preserve">
           <source>Weedle has an extremely acute sense of smell. It is capable of distinguishing its favorite kinds of leaves from those it dislikes just by sniffing with its big red proboscis (nose).</source>
-          <target state="translated">Weedle har en ekstremt skarp luktesans. Den er i stand til å skille ut sine favoritt blader fra de den misliker ved sniffing med sin store røde nese.</target>
+          <target state="final">Weedle har en ekstremt skarp luktesans. Den er i stand til å skille ut sine favoritt blader fra de den misliker ved sniffing med sin store røde nese.</target>
         </trans-unit>
         <trans-unit id="Kakuna.Description" translate="yes" xml:space="preserve">
           <source>Kakuna remains virtually immobile as it clings to a tree. However, on the inside, it is extremely busy as it prepares for its coming evolution. This is evident from how hot the shell becomes to the touch.</source>
@@ -2516,7 +2521,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Pidgeotto.Description" translate="yes" xml:space="preserve">
           <source>Pidgeotto claims a large area as its own territory. This Pokémon flies around, patrolling its living space. If its territory is violated, it shows no mercy in thoroughly punishing the foe with its sharp claws.</source>
-          <target state="translated">Pidgeotto tar store områder og lager det til sitt eget territorium. Den flyr rundt og patruljerer sitt territorium. Hvis territoriumet blir forstyrret, viser den ingen nåde og vil grundig straffe fienden med sine skarpe klør.</target>
+          <target state="final">Pidgeotto tar store områder og lager det til sitt eget territorium. Den flyr rundt og patruljerer sitt territorium. Hvis territoriumet blir forstyrret, viser den ingen nåde og vil grundig straffe fienden med sine skarpe klør.</target>
         </trans-unit>
         <trans-unit id="Pidgeot.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon has a dazzling plumage of beautifully glossy feathers. Many Trainers are captivated by the striking beauty of the feathers on its head, compelling them to choose Pidgeot as their Pokémon.</source>
@@ -2524,7 +2529,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Rattata.Description" translate="yes" xml:space="preserve">
           <source>Rattata is cautious in the extreme. Even while it is asleep, it constantly listens by moving its ears around. It is not picky about where it lives—it will make its nest anywhere.</source>
-          <target state="translated">Rattata er svært forsiktig. Selv når den hviler, lytter den stadig etter lyder ved å bevege ørene. Den er ikke kresen om hvor den bor. Den lager reir overalt!</target>
+          <target state="final">Rattata er svært forsiktig. Selv når den hviler, lytter den stadig etter lyder ved å bevege ørene. Den er ikke kresen om hvor den bor. Den lager reir overalt!</target>
         </trans-unit>
         <trans-unit id="Raticate.Description" translate="yes" xml:space="preserve">
           <source>Raticate’s sturdy fangs grow steadily. To keep them ground down, it gnaws on rocks and logs. It may even chew on the walls of houses.</source>
@@ -2532,7 +2537,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Spearow.Description" translate="yes" xml:space="preserve">
           <source>Spearow has a very loud cry that can be heard over half a mile away. If its high, keening cry is heard echoing all around, it is a sign that they are warning each other of danger.</source>
-          <target state="translated">Spearow har et svært høyt rop som kan høres over en kilometer unna. Hvis du hører mange av ropene i et ekko, er det et tegn på at de advarer hverandre for potensiell fare.</target>
+          <target state="final">Spearow har et svært høyt rop som kan høres over en kilometer unna. Hvis du hører mange av ropene i et ekko, er det et tegn på at de advarer hverandre for potensiell fare.</target>
         </trans-unit>
         <trans-unit id="Fearow.Description" translate="yes" xml:space="preserve">
           <source>Fearow is recognized by its long neck and elongated beak. They are conveniently shaped for catching prey in soil or water. It deftly moves its long and skinny beak to pluck prey.</source>
@@ -2552,7 +2557,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Raichu.Description" translate="yes" xml:space="preserve">
           <source>This Pokémon exudes a weak electrical charge from all over its body that makes it take on a slight glow in darkness. Raichu plants its tail in the ground to discharge electricity.</source>
-          <target state="translated">Denne Pokémonen utstråler en svak elektrisk ladning fra kroppen. Dette gjør at den har en svak glød i mørke. Raichu kan sette halen i bakken for å slippe ut elektrisitet.</target>
+          <target state="final">Denne Pokémonen utstråler en svak elektrisk ladning fra kroppen. Dette gjør at den har en svak glød i mørke. Raichu kan sette halen i bakken for å slippe ut elektrisitet.</target>
         </trans-unit>
         <trans-unit id="Sandshrew.Description" translate="yes" xml:space="preserve">
           <source>Sandshrew has a very dry hide that is extremely tough. The Pokémon can roll into a ball that repels any attack. At night, it burrows into the desert sand to sleep.</source>
@@ -2564,7 +2569,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranFemale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♀ has barbs that secrete a powerful poison. They are thought to have developed as protection for this small-bodied Pokémon. When enraged, it releases a horrible toxin from its horn.</source>
-          <target state="translated">Nidoran♀ har pigger med mothaker som sender ut en kraftig gift. Piggene er antatt å ha utviklet seg som beskyttelse for denne lille Pokémonen. Når den blir rasende sender den ut en fryktelig toksin fra hornene.</target>
+          <target state="final">Nidoran♀ har pigger med mothaker som sender ut en kraftig gift. Piggene er antatt å ha utviklet seg som beskyttelse for denne lille Pokémonen. Når den blir rasende sender den ut en fryktelig toksin fra hornene.</target>
         </trans-unit>
         <trans-unit id="Nidorina.Description" translate="yes" xml:space="preserve">
           <source>When Nidorina are with their friends or family, they keep their barbs tucked away to prevent hurting each other. This Pokémon appears to become nervous if separated from the others.</source>
@@ -2576,7 +2581,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="NidoranMale.Description" translate="yes" xml:space="preserve">
           <source>Nidoran♂ has developed muscles for moving its ears. Thanks to them, the ears can be freely moved in any direction. Even the slightest sound does not escape this Pokémon’s notice.</source>
-          <target state="translated">Nidoran♂ har utviklet muskler for å flytte ørene rundt omkring. Takket være dem, kan ørene fritt flyttes i alle retninger. Selv den minste lyd, kan ikke unnslippe å bli hørt av ørene.</target>
+          <target state="final">Nidoran♂ har utviklet muskler for å flytte ørene rundt omkring. Takket være dem, kan ørene fritt flyttes i alle retninger. Selv den minste lyd, kan ikke unnslippe å bli hørt av ørene.</target>
         </trans-unit>
         <trans-unit id="Nidorino.Description" translate="yes" xml:space="preserve">
           <source>Nidorino has a horn that is harder than a diamond. If it senses a hostile presence, all the barbs on its back bristle up at once, and it challenges the foe with all its might.</source>
@@ -2596,7 +2601,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Vulpix.Description" translate="yes" xml:space="preserve">
           <source>Inside Vulpix’s body burns a flame that never goes out. During the daytime, when the temperatures rise, this Pokémon releases flames from its mouth to prevent its body from growing too hot.</source>
-          <target state="translated">Inne i Vulpixs sin kropp, brenner en flamme som aldri går ut. På dagtid, når temperaturen stiger, sender Pokémonen ut flammer fra munnen for å hindre at kroppen blir for varmt.</target>
+          <target state="final">Inne i Vulpixs sin kropp, brenner en flamme som aldri går ut. På dagtid, når temperaturen stiger, sender Pokémonen ut flammer fra munnen for å hindre at kroppen blir for varmt.</target>
         </trans-unit>
         <trans-unit id="Ninetales.Description" translate="yes" xml:space="preserve">
           <source>Legend has it that Ninetales came into being when nine wizards possessing sacred powers merged into one. This Pokémon is highly intelligent—it can understand human speech.</source>
@@ -2612,7 +2617,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Zubat.Description" translate="yes" xml:space="preserve">
           <source>Zubat avoids sunlight because exposure causes it to become unhealthy. During the daytime, it stays in caves or under the eaves of old houses, sleeping while hanging upside down.</source>
-          <target state="translated">Zubat unngår sollys fordi eksponering fører at den blir dårlig. På dagtid oppholder den deg i huler eller under tak i gamle hus. Den sover hengende opp ned.</target>
+          <target state="final">Zubat unngår sollys fordi eksponering fører at den blir dårlig. På dagtid oppholder den deg i huler eller under tak i gamle hus. Den sover hengende opp ned.</target>
         </trans-unit>
         <trans-unit id="Golbat.Description" translate="yes" xml:space="preserve">
           <source>Golbat bites down on prey with its four fangs and drinks the victim’s blood. It becomes active on inky dark moonless nights, flying around to attack people and Pokémon.</source>
@@ -2620,7 +2625,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Oddish.Description" translate="yes" xml:space="preserve">
           <source>Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this Pokémon’s feet are thought to change shape and become similar to the roots of trees.</source>
-          <target state="translated">Oddish søker etter fruktbar, næringsrik jord, der den kan plante seg selv. På dagtid, mens den er plantet, er Pokémonen sine føtter antatt å endre form til røtter.</target>
+          <target state="final">Oddish søker etter fruktbar, næringsrik jord, der den kan plante seg selv. På dagtid, mens den er plantet, er Pokémonen sine føtter antatt å endre form til røtter.</target>
         </trans-unit>
         <trans-unit id="Gloom.Description" translate="yes" xml:space="preserve">
           <source>From its mouth Gloom drips honey that smells absolutely horrible. Apparently, it loves the horrid stench. It sniffs the noxious fumes and then drools even more of its honey.</source>
@@ -2664,7 +2669,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Psyduck.Description" translate="yes" xml:space="preserve">
           <source>If it uses its mysterious power, Psyduck can’t remember having done so. It apparently can’t form a memory of such an event because it goes into an altered state that is much like deep sleep.</source>
-          <target state="translated">Hvis den bruker sin mystiske kraft, kan ikke Psyduck huske at den har brukt den. Den klarer ikke forme et minne av en slik hendelse fordi den går inn i en meditativ tilstand. Denne tilstanden er ganske lik dyp søvn.</target>
+          <target state="final">Hvis den bruker sin mystiske kraft, kan ikke Psyduck huske at den har brukt den. Den klarer ikke forme et minne av en slik hendelse fordi den går inn i en meditativ tilstand. Denne tilstanden er ganske lik dyp søvn.</target>
         </trans-unit>
         <trans-unit id="Golduck.Description" translate="yes" xml:space="preserve">
           <source>Golduck is the fastest swimmer among all Pokémon. It swims effortlessly, even in a rough, stormy sea. It sometimes rescues people from wrecked ships floundering in high seas.</source>
@@ -2724,7 +2729,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Bellsprout.Description" translate="yes" xml:space="preserve">
           <source>Bellsprout’s thin and flexible body lets it bend and sway to avoid any attack, however strong it may be. From its mouth, this Pokémon spits a corrosive fluid that melts even iron.</source>
-          <target state="translated">Bellsprout har en tynn og fleksibel kropp som lar den svinge og svaie seg for å unngå alle angrep. Den må ikke bli undervurdert. Fra munnen spytter den en korroderende væske som til og med kan smelte jern.</target>
+          <target state="final">Bellsprout har en tynn og fleksibel kropp som lar den svinge og svaie seg for å unngå alle angrep. Den må ikke bli undervurdert. Fra munnen spytter den en korroderende væske som til og med kan smelte jern.</target>
         </trans-unit>
         <trans-unit id="Weepinbell.Description" translate="yes" xml:space="preserve">
           <source>Weepinbell has a large hook on its rear end. At night, the Pokémon hooks on to a tree branch and goes to sleep. If it moves around in its sleep, it may wake up to find itself on the ground.</source>
@@ -2832,7 +2837,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Drowzee.Description" translate="yes" xml:space="preserve">
           <source>If your nose becomes itchy while you are sleeping, it’s a sure sign that one of these Pokémon is standing above your pillow and trying to eat your dream through your nostrils.</source>
-          <target state="translated">Hvis nesen din blir kløende mens du sover, er det et sikkert tegn på at en av denne Pokémonen står ovenfor sengen din for å prøve å ta drømmene dine.</target>
+          <target state="final">Hvis nesen din blir kløende mens du sover, er det et sikkert tegn på at en av denne Pokémonen står ovenfor sengen din for å prøve å ta drømmene dine.</target>
         </trans-unit>
         <trans-unit id="Hypno.Description" translate="yes" xml:space="preserve">
           <source>Hypno holds a pendulum in its hand. The arcing movement and glitter of the pendulum lull the foe into a deep state of hypnosis. While this Pokémon searches for prey, it polishes the pendulum.</source>
@@ -3052,7 +3057,7 @@ Du fikk også {1} Stjernestøv, {2} Candy og {3} XP.</target>
         </trans-unit>
         <trans-unit id="Mew.Description" translate="yes" xml:space="preserve">
           <source>Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</source>
-          <target state="needs-review-translation">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
+          <target state="translated">Mew is said to possess the genetic composition of all Pokémon. It is capable of making itself invisible at will, so it entirely avoids notice even if it approaches people.</target>
         </trans-unit>
       </group>
     </body>


### PR DESCRIPTION
Changes
-------
- Updated "nb-NO" translations.
- Changed some translations
- Cloned "nb-NO" translation into the "nn-NO" translation. This is because "nb-NO" and "nn-NO" is basically the same written language.

Change details
--------------
- Fixed alot of spelling errors and improved the translation overall
- Started to translate the Pokemon descriptions
- Other informations

Other informations
------------------
- Sorted all transaltions in "microsoft multilingual app toolkit" (Added the Need Review, Translated and Final tags)

