### PR TITLE
show the autoupdate button only when the map is actually moved

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml.cs
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml.cs
@@ -14,7 +14,9 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PokemonGo.RocketAPI;
 using PokemonGo_UWP.Utils;
+using PokemonGo_UWP.Utils.Helpers;
 using Template10.Common;
+
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -158,8 +160,10 @@ namespace PokemonGo_UWP.Views
 
         private void GameMapControl_TargetCameraChanged(MapControl sender, MapTargetCameraChangedEventArgs args)
         {
-            if ((args.ChangeReason == MapCameraChangeReason.UserInteraction) && (lastAutoPosition != null))
-                ReactivateMapAutoUpdateButton.Visibility = Visibility.Visible;
+            var distance = GeoHelper.Distance(lastAutoPosition, args.Camera.Location);
+ +            if (args.ChangeReason == MapCameraChangeReason.UserInteraction && lastAutoPosition != null && distance > 0) {
+                  ReactivateMapAutoUpdateButton.Visibility = Visibility.Visible;
+              }
         }
 
         private void GameMapControl_OnZoomLevelChanged(MapControl sender, object args)


### PR DESCRIPTION
Closes issues
-------------
- Fixes #1385 conflicts
- if you press the tilt or autorotate button on the map, the autoupdate button appears;

Changes
-------
- check if the distance between lastAutoposition and the location of the map camera is greater than 0


