### PR TITLE
Added a Pokestop info button (Currently only searches Google)

### DIFF
--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -111,12 +111,15 @@
             <Grid Grid.Row="0" Style="{StaticResource GridContainer}">
                 <TextBlock Text="{Binding CurrentPokestopInfo.Name}" 
                            Style="{StaticResource TextPokestopTitle}"
-                           VerticalAlignment="Center"/>
+                           VerticalAlignment="Top"/>
                 <Button Content=">"
                         HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
                         Background="Transparent"
                         Click="startSearch"
-                        Tag="{Binding CurrentPokestopInfo.Name}" />
+                        Tag="{Binding CurrentPokestopInfo.Name}"
+                        Height="50"
+                        Width="50" />
             </Grid>
 
             <Border Grid.Row="1"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -113,7 +113,7 @@
                            Style="{StaticResource TextPokestopTitle}"
                            VerticalAlignment="Top"
                            HorizontalAlignment="Left" />
-                <Button Content="Learn More"
+                <Button Content="Learn More..."
                         HorizontalAlignment="Right"
                         VerticalAlignment="Bottom"
                         Background="Transparent"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -111,7 +111,8 @@
             <Grid Grid.Row="0" Style="{StaticResource GridContainer}">
                 <TextBlock Text="{Binding CurrentPokestopInfo.Name}" 
                            Style="{StaticResource TextPokestopTitle}"
-                           VerticalAlignment="Top"/>
+                           VerticalAlignment="Top"
+                           HorizontalAlignment="Left" />
                 <Button Content="Learn More"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Bottom"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="PokemonGo_UWP.Views.SearchPokestopPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -109,8 +109,10 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Style="{StaticResource GridContainer}">
-                <TextBlock Text="{Binding CurrentPokestopInfo.Name}"
-                           Style="{StaticResource TextPokestopTitle}" />
+                <Button Content="{Binding CurrentPokestopInfo.Name}"
+                        Background="Transparent"
+                        Click="startSearch"
+                        Tag="{Binding CurrentPokestopInfo.Name}" />
             </Grid>
 
             <Border Grid.Row="1"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -112,14 +112,12 @@
                 <TextBlock Text="{Binding CurrentPokestopInfo.Name}" 
                            Style="{StaticResource TextPokestopTitle}"
                            VerticalAlignment="Top"/>
-                <Button Content=">"
+                <Button Content="Learn More"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Bottom"
                         Background="Transparent"
                         Click="startSearch"
-                        Tag="{Binding CurrentPokestopInfo.Name}"
-                        Height="50"
-                        Width="50" />
+                        Tag="{Binding CurrentPokestopInfo.Name}" />
             </Grid>
 
             <Border Grid.Row="1"

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml
@@ -109,7 +109,11 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Style="{StaticResource GridContainer}">
-                <Button Content="{Binding CurrentPokestopInfo.Name}"
+                <TextBlock Text="{Binding CurrentPokestopInfo.Name}" 
+                           Style="{StaticResource TextPokestopTitle}"
+                           VerticalAlignment="Center"/>
+                <Button Content=">"
+                        HorizontalAlignment="Right"
                         Background="Transparent"
                         Click="startSearch"
                         Tag="{Binding CurrentPokestopInfo.Name}" />

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -89,7 +89,7 @@ namespace PokemonGo_UWP.Views
             var pokestopName = ((Button)sender).Tag;
 
             // The URI to launch
-            var uriSearch = new Uri(@"http://www.bing.com/search?q=" + pokestopName);
+            var uriSearch = new Uri(@"http://www.google.com/search?q=" + pokestopName);
 
             // Launch the URI
             var success = await Windows.System.Launcher.LaunchUriAsync(uriSearch);

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -80,6 +81,28 @@ namespace PokemonGo_UWP.Views
         {
             SearchPokestopButton.IsEnabled = false;
             SpinPokestopImage.Begin();
+        }
+
+        private async void startSearch(object sender, RoutedEventArgs e)
+        {
+            //Gets data for link
+            var pokestopName = ((Button)sender).Tag;
+
+            // The URI to launch
+            var uriSearch = new Uri(@"http://www.bing.com/search?q=" + pokestopName);
+
+            // Launch the URI
+            var success = await Windows.System.Launcher.LaunchUriAsync(uriSearch);
+
+            if (success)
+            {
+                // URI launched
+            }
+            else
+            {
+                var dialog = new MessageDialog("Failed to open browser");
+                await dialog.ShowAsync();
+            }
         }
 
         #endregion

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -100,7 +100,7 @@ namespace PokemonGo_UWP.Views
             }
             else
             {
-                var dialog = new MessageDialog("Failed to open browser");
+                var dialog = new MessageDialog("Error!");
                 await dialog.ShowAsync();
             }
         }

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -94,11 +94,7 @@ namespace PokemonGo_UWP.Views
             // Launch the URI
             var success = await Windows.System.Launcher.LaunchUriAsync(uriSearch);
 
-            if (success)
-            {
-                // URI launched
-            }
-            else
+            if (!success)
             {
                 var dialog = new MessageDialog("Error!");
                 await dialog.ShowAsync();

--- a/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
+++ b/PokemonGo-UWP/Views/SearchPokestopPage.xaml.cs
@@ -85,20 +85,35 @@ namespace PokemonGo_UWP.Views
 
         private async void startSearch(object sender, RoutedEventArgs e)
         {
-            //Gets data for link
-            var pokestopName = ((Button)sender).Tag;
+            var question = new Windows.UI.Popups.MessageDialog(
+                           "This will open your browser", 
+                           "Opening Browser...");
+            dialog.Commands.Add(new Windows.UI.Popups.UICommand("Ok") { Id = 0 });
+            dialog.Commands.Add(new Windows.UI.Popups.UICommand("No") { Id = 1 });
+            dialog.DefaultCommandIndex = 0;
+            dialog.Cancel.CommandIndex = 1;
+            
+            var result = await dialog.ShowAsync();
+            
+            if (result.Id == 0) {
+                //Gets data for link
+                var pokestopName = ((Button)sender).Tag;
 
-            // The URI to launch
-            var uriSearch = new Uri(@"http://www.google.com/search?q=" + pokestopName);
+                // The URI to launch
+                var uriSearch = new Uri(@"http://www.google.com/search?q=" + pokestopName);
 
-            // Launch the URI
-            var success = await Windows.System.Launcher.LaunchUriAsync(uriSearch);
+                // Launch the URI
+                var success = await Windows.System.Launcher.LaunchUriAsync(uriSearch);
 
-            if (!success)
-            {
-                var dialog = new MessageDialog("Error!");
-                await dialog.ShowAsync();
+                if (!success)
+                {
+                    var dialog = new MessageDialog("Error!");
+                    await dialog.ShowAsync();
+                }
+            } else {
+                //no permission to open browser
             }
+            
         }
 
         #endregion


### PR DESCRIPTION
Closes issues
-------------
- Closes no issues

Changes
-------
- Added pokestop info button (Learn More)
- Clicking the pokestop info button will ask you before opening browser (Until webview implemented)
- Allowing the app to open the browser will send you to ~~Bing~~ Google in your browser searching the pokestops name

Questions
-----------
Is there a way to make the error message use the multi-lingual resources?
How would I make the button's text (content) bigger?
Should I add option to change search engine?

Note to devs
---------------
Don't Merge Yet, Testing and adding more stuff, please consider merging once todo's are empty.

To Do
---------
Make the search appear in a separate game page called "PokestopInfo.xaml" using a webview
Make the webview have some basic controls (Forward, Backward and return to original search)
Make an option to change which search engine to use
~~Make info button (>) bigger to match button size~~

Other Information
--------------------
Now uses Google because Bing shows a bunch of alternate content/sponsored content at top of search on mobile.
Now asks before opening browser (Until webview implemented) to avoid accidental opening.

Why did I do this?
--------------------
I did this because I think when people are going to landmarks, they should be able to learn more about it, so I implemented this.