### PR TITLE
Fixed crash in Pokedex

### DIFF
--- a/PokemonGo-UWP/ViewModels/PokedexPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokedexPageViewModel.cs
@@ -114,9 +114,10 @@ namespace PokemonGo_UWP.ViewModels
         public DelegateCommand<PokemonId> OpenPokedexEntry =>
             _openPokedexEntry ??
             (_openPokedexEntry = new DelegateCommand<PokemonId>(
-                (x) =>
+                (id) =>
                 {
-                    NavigationService.Navigate(typeof(PokedexDetailPage), x);
+                    if (GameClient.PokedexInventory.Count(x => x.PokemonId == id) == 0) return;
+                    NavigationService.Navigate(typeof(PokedexDetailPage), id);
                 },
                     (x) => true)
             );


### PR DESCRIPTION
Changes
-------
- Fixed crash introduced in #1544

Change details
--------------
- Fixes bug that caused a crash when tapping on a Pokedex entry for a Pokemon, that was not yet spotted.
