### PR TITLE
Windows GPS Accuracy API + PTC Token Fix

### DIFF
--- a/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
+++ b/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
@@ -206,7 +206,8 @@ namespace PokemonGo_UWP.Utils
                 loc.TimeSnapshot = DeviceInfos.RelativeTimeFromStart;
 
                 loc.HorizontalAccuracy = (float?)GameClient.Geoposition.Coordinate?.SatelliteData.HorizontalDilutionOfPrecision ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
-                loc.VerticalAccuracy = (float?)GameClient.Geoposition.Coordinate?.SatelliteData.VerticalDilutionOfPrecision ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
+                // @robertmclaws: VericalAccuracy is not currently transmitted in the payload. 
+                //loc.VerticalAccuracy = (float?)GameClient.Geoposition.Coordinate?.SatelliteData.VerticalDilutionOfPrecision ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
 
                 return loc;
             }

--- a/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
+++ b/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
@@ -208,7 +208,8 @@ namespace PokemonGo_UWP.Utils
 
                 loc.TimeSnapshot = DeviceInfos.RelativeTimeFromStart;
 
-                loc.HorizontalAccuracy = (float?)GameClient.Geoposition.Coordinate?.Accuracy ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
+                loc.HorizontalAccuracy = (float?)GameClient.Geoposition.Coordinate?.SatelliteData.HorizontalDilutionOfPrecision ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
+                loc.VerticalAccuracy = (float?)GameClient.Geoposition.Coordinate?.SatelliteData.VerticalDilutionOfPrecision ?? (float)Math.Floor((float)_random.NextGaussian(1.0, 1.0)); //better would be exp distribution
 
                 return loc;
             }

--- a/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
+++ b/PokemonGo-UWP/Utils/Signature/DeviceInfosAndroid.cs
@@ -2,9 +2,6 @@
 using Superbest_random;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Devices.Sensors;
 
 namespace PokemonGo_UWP.Utils

--- a/PokemonGoAPI/Login/PtcLogin.cs
+++ b/PokemonGoAPI/Login/PtcLogin.cs
@@ -74,7 +74,6 @@ namespace PokemonGo.RocketAPI.Login
         public async Task<AccessToken> GetAccessToken()
         {
                 // robertmclaws: Should we be setting every UserAgent property like the other requests?
-
                 var loginData = await GetLoginParameters().ConfigureAwait(false);
                 var authTicket = await GetAuthenticationTicket(loginData).ConfigureAwait(false);
                 var accessToken = await GetOAuthToken(authTicket).ConfigureAwait(false);
@@ -176,7 +175,8 @@ namespace PokemonGo.RocketAPI.Login
             {
                 Username = this.Username,
                 Token = decoder.GetFirstValueByName("access_token"),
-                ExpiresUtc = DateTime.UtcNow.AddSeconds(int.Parse(decoder.GetFirstValueByName("expires"))),
+                // @robertmclaws: Subtract 1 hour from the token to solve this issue: https://github.com/pogodevorg/pgoapi/issues/86
+                ExpiresUtc = DateTime.UtcNow.AddSeconds(int.Parse(decoder.GetFirstValueByName("expires")) - 3600),
                 AuthType = AuthType.Ptc
             };
         }


### PR DESCRIPTION
- I believe `HorizontalAccuracy` referrs to HDOP and the missing `VerticalAccuracy` refers to VDOP. (We're not using the Android code right now, but this might help on the iOS side too.)
-  Fixing a PtcLogin issue documented on PogoDev. See the code comment for a url referring to the issue in question. I don't want to link to it directly.