### PR TITLE
Cannot transfer Pokémon, if it is a favorite

### DIFF
--- a/PokemonGo-UWP/Strings/en-US/CodeResources.resw
+++ b/PokemonGo-UWP/Strings/en-US/CodeResources.resw
@@ -337,4 +337,7 @@ You also got {1} Stardust, {2} Candy and {3} XP.</value>
   <data name="PokemonEncounterNotInRangeText" xml:space="preserve">
     <value>{0} is not in catch range anymore.</value>
   </data>
+  <data name="CannotTransferFavorite" xml:space="preserve">
+    <value>Cannot transfer a favorite Pokémon!</value>
+  </data>
 </root>

--- a/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/PokemonDetailsPageViewModel.cs
@@ -344,6 +344,15 @@ namespace PokemonGo_UWP.ViewModels
         public DelegateCommand TransferPokemonCommand => _transferPokemonCommand ?? (
           _transferPokemonCommand = new DelegateCommand(() =>
           {
+              if(IsFavorite) {
+                  var cannotTransferDialog = new PoGoMessageDialog(Resources.CodeResources.GetString("CannotTransferFavorite"), "")
+                  {
+                      CoverBackground = true,
+                      AnimationType = PoGoMessageDialogAnimation.Bottom
+                  };
+                  cannotTransferDialog.Show();
+                  return;
+              }
               // Ask for confirmation before moving the Pokemon
               var name = Resources.Pokemon.GetString(CurrentPokemon.PokemonId.ToString());
               var dialog =


### PR DESCRIPTION
Closes issues
-------------
- Closes #1539 

Changes
-------
- Pokémon cannot be transfered, if it's a favorite

Change details
--------------
If the user will Transfer a favorite Pokémon, there will be shown a message, that it's not able to Transfer it. It know, the message is different to the original one, but I think, it Looks better with the PogoMessageDialog.

Other informations
![favorite](https://cloud.githubusercontent.com/assets/20780000/18254866/b93b12e6-73a2-11e6-94ba-adc8216955b6.png)



