### PR TITLE
Fixed main map's nearby panel to show three pokemons (Take two)

### DIFF
--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -696,9 +696,9 @@
               Canvas.ZIndex="2"
               Height="100">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="35*" />
+                <ColumnDefinition Width="30*" />
+                <ColumnDefinition Width="35*" />
             </Grid.ColumnDefinitions>
 
             <RelativePanel x:Name="UserDetailsPanel"
@@ -785,7 +785,7 @@
                     VerticalAlignment="Center"
                     Grid.Column="2"
                     Tapped="ToggleNearbyPokemonModal"
-                    Padding="4"
+                    Padding="0"
                     Height="55">
 
                 <Border.Background>
@@ -806,7 +806,7 @@
                         <ItemsPanelTemplate>
                             <WrapGrid Orientation="Horizontal"
                                       VerticalChildrenAlignment="Top"
-                                      MaximumRowsOrColumns="10"
+                                      MaximumRowsOrColumns="3"
                                       ItemHeight="52"
                                       ItemWidth="40"
                                       ScrollViewer.VerticalScrollMode="Disabled"
@@ -824,15 +824,18 @@
                                        HorizontalAlignment="Center"
                                        Stretch="Uniform"                                        
                                        Height="36"
-                                       Width="36" />
+                                       Width="28"
+                                       Margin="1,0" />
 
                                 <BitmapIcon
                                     UriSource="{Binding PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}, ConverterParameter=uri}"
                                     Style="{ThemeResource NearbyPokemonNotInPokedexBitmapIconStyle}"
                                     Visibility="{Binding PokemonId, Converter={StaticResource InverseNearbyPokemonInPokedexToVisibilityConverter}}"
+                                    VerticalAlignment="Center"
                                     HorizontalAlignment="Center"                                    
                                     Height="36"
-                                    Width="36" />
+                                    Width="28"
+                                    Margin="1,0" />
                             </Grid>
                         </DataTemplate>
                     </GridView.ItemTemplate>

--- a/PokemonGo-UWP/Views/GameMapPage.xaml
+++ b/PokemonGo-UWP/Views/GameMapPage.xaml
@@ -806,7 +806,7 @@
                         <ItemsPanelTemplate>
                             <WrapGrid Orientation="Horizontal"
                                       VerticalChildrenAlignment="Top"
-                                      MaximumRowsOrColumns="3"
+                                      MaximumRowsOrColumns="10"
                                       ItemHeight="52"
                                       ItemWidth="40"
                                       ScrollViewer.VerticalScrollMode="Disabled"


### PR DESCRIPTION
Closes issues
-------------
- Closes #1258 

Changes
-------
- Changed margins and pic sizes on nearby panel of the main map to show max three pokemons.

Change details
--------------


Other informations
-Some pokemons appear quite small, but compared to original app they are about the same size if not bigger

