### PR TITLE
Resized Pokemon Image in Detail Page

### DIFF
--- a/PokemonGo-UWP/Views/PokemonDetailPage.xaml
+++ b/PokemonGo-UWP/Views/PokemonDetailPage.xaml
@@ -576,12 +576,10 @@
                         <Viewbox Grid.Row="1"
                                  Grid.ColumnSpan="3"
                                  Margin="30,30,30,-32"
-                                 MaxWidth="310"
                                  VerticalAlignment="Bottom"
-                                 HorizontalAlignment="Center"
+                                 HorizontalAlignment="Stretch"
                                  StretchDirection="DownOnly">
                             <Image x:Name="PokemonImage"
-                               Height="128"
                                Source="{Binding CurrentPokemon.PokemonId, Converter={StaticResource PokemonIdToPokemonSpriteConverter}}"
                                Canvas.ZIndex="5"
                                Stretch="Uniform"/>


### PR DESCRIPTION
Closes issues
-------------
- Closes #1608 

Changes
-------
- Changed: Size of Pokemon Images in Details page is now bigger

Change details
--------------
Here a screenshot. What dou you mean?
![pokemon detail](https://cloud.githubusercontent.com/assets/20780000/18416493/e8988b68-7816-11e6-8994-bd077d5db30c.png)


