### PR TITLE
Corrected Omanyte translation

### DIFF
--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.it.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.it.xlf
@@ -1413,7 +1413,7 @@ Hai ottenuto anche {1} Polvere di stella, {2} Caramelle e {3} PE.</target>
         </trans-unit>
         <trans-unit id="Omanyte" translate="yes" xml:space="preserve">
           <source>Omanyte</source>
-          <target state="final">Omanyteì</target>
+          <target state="final">Omanyte</target>
         </trans-unit>
         <trans-unit id="Omastar" translate="yes" xml:space="preserve">
           <source>Omastar</source>


### PR DESCRIPTION
Changes
-------
- Corrected Omanyte translation for Italian

Omanyte was wrote wrong (Omanyteì)
------------------


