### PR TITLE
Fix 30 Minute Login Failure

### DIFF
--- a/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
+++ b/PokemonGo-UWP/ViewModels/CapturePokemonPageViewModel.cs
@@ -258,7 +258,7 @@ namespace PokemonGo_UWP.ViewModels
             set
             {
                 // If user selected a berry we need to see if he can select it
-                if (!_canUseBerry &&
+                if (!_canUseBerry && value != null &&
                     (value.ItemId == ItemId.ItemRazzBerry || value.ItemId == ItemId.ItemBlukBerry ||
                      value.ItemId == ItemId.ItemNanabBerry || value.ItemId == ItemId.ItemWeparBerry ||
                      value.ItemId == ItemId.ItemPinapBerry))

--- a/PokemonGoAPI/Exceptions/LoginFailedException.cs
+++ b/PokemonGoAPI/Exceptions/LoginFailedException.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace PokemonGo.RocketAPI.Exceptions
 {

--- a/PokemonGoAPI/Extensions/CookieContainerExtensions.cs
+++ b/PokemonGoAPI/Extensions/CookieContainerExtensions.cs
@@ -5,29 +5,30 @@ namespace System.Net
 {
 
     /// <summary>
-    /// 
+    /// Contains extensions for the <see cref="CookieContaner"/> class.
     /// </summary>
     public static class CookieContainerExtensions
     {
 
         /// <summary>
-        /// 
+        /// Uses Reflection to get ALL of the <see cref="Cookie">Cookies</see> where <see cref="Cookie.Domain"/> 
+        /// contains part of the specified string. Will return cookies for any subdomain, as well as dotted-prefix cookies. 
         /// </summary>
-        /// <param name="cookieContainer"></param>
-        /// <param name="domain"></param>
+        /// <param name="cookieContainer">The <see cref="CookieContainer"/> to extract the <see cref="Cookie">Cookies</see> from.</param>
+        /// <param name="domain">The string that contains part of the domain you want to extract cookies for.</param>
         /// <returns></returns>
-        internal static IEnumerable<Cookie> GetCookies(this CookieContainer cookieContainer, string domain)
+        public static IEnumerable<Cookie> GetCookies(this CookieContainer cookieContainer, string domain)
         {
-            dynamic domainTable = GetInstanceField(cookieContainer, "_domainTable");
+            var domainTable = GetFieldValue<dynamic>(cookieContainer, "_domainTable");
             foreach (var entry in domainTable)
             {
                 string key = GetPropertyValue<string>(entry, "Key");
 
                 if (key.Contains(domain))
                 {
-                    dynamic value = GetPropertyValue<dynamic>(entry, "Value");
+                    var value = GetPropertyValue<dynamic>(entry, "Value");
 
-                    var internalList = (SortedList<string, CookieCollection>)GetInstanceField(value, "_list");
+                    var internalList = (SortedList<string, CookieCollection>)GetFieldValue(value, "_list");
                     foreach (var li in internalList)
                     {
                         foreach (Cookie cookie in li.Value)
@@ -40,25 +41,25 @@ namespace System.Net
         }
 
         /// <summary>
-        /// 
+        /// Gets the value of a Field for a given object instance.
         /// </summary>
-        /// <param name="instance"></param>
-        /// <param name="fieldName"></param>
+        /// <typeparam name="T">The <see cref="Type"/> you want the value to be converted to when returned.</typeparam>
+        /// <param name="instance">The Type instance to extract the Field's data from.</param>
+        /// <param name="fieldName">The name of the Field to extract the data from.</param>
         /// <returns></returns>
-        internal static object GetInstanceField(object instance, string fieldName)
+        internal static T GetFieldValue<T>(object instance, string fieldName)
         {
-            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
-                | BindingFlags.Static;
-            FieldInfo field = instance.GetType().GetField(fieldName, bindFlags);
-            return field.GetValue(instance);
+            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+            FieldInfo fi = instance.GetType().GetField(fieldName, bindFlags);
+            return (T)fi.GetValue(instance);
         }
 
         /// <summary>
-        /// 
+        /// Gets the value of a Property for a given object instance.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="instance"></param>
-        /// <param name="propertyName"></param>
+        /// <typeparam name="T">The <see cref="Type"/> you want the value to be converted to when returned.</typeparam>
+        /// <param name="instance">The Type instance to extract the Property's data from.</param>
+        /// <param name="propertyName">The name of the Property to extract the data from.</param>
         /// <returns></returns>
         internal static T GetPropertyValue<T>(object instance, string propertyName)
         {

--- a/PokemonGoAPI/Extensions/CookieContainerExtensions.cs
+++ b/PokemonGoAPI/Extensions/CookieContainerExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.Net
+{
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class CookieContainerExtensions
+    {
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cookieContainer"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        internal static IEnumerable<Cookie> GetCookies(this CookieContainer cookieContainer, string domain)
+        {
+            dynamic domainTable = GetInstanceField(cookieContainer, "_domainTable");
+            foreach (var entry in domainTable)
+            {
+                string key = GetPropertyValue<string>(entry, "Key");
+
+                if (key.Contains(domain))
+                {
+                    dynamic value = GetPropertyValue<dynamic>(entry, "Value");
+
+                    var internalList = (SortedList<string, CookieCollection>)GetInstanceField(value, "_list");
+                    foreach (var li in internalList)
+                    {
+                        foreach (Cookie cookie in li.Value)
+                        {
+                            yield return cookie;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="fieldName"></param>
+        /// <returns></returns>
+        internal static object GetInstanceField(object instance, string fieldName)
+        {
+            BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+                | BindingFlags.Static;
+            FieldInfo field = instance.GetType().GetField(fieldName, bindFlags);
+            return field.GetValue(instance);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="instance"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        internal static T GetPropertyValue<T>(object instance, string propertyName)
+        {
+            var pi = instance.GetType().GetProperty(propertyName);
+            return (T)pi.GetValue(instance, null);
+        }
+
+    }
+
+}

--- a/PokemonGoAPI/Login/PtcLogin.cs
+++ b/PokemonGoAPI/Login/PtcLogin.cs
@@ -26,6 +26,8 @@ namespace PokemonGo.RocketAPI.Login
 
         private static HttpClient HttpClient;
 
+        private static CookieContainer Cookies;
+
         /// <summary>
         /// The Password for the user currently attempting  to authenticate.
         /// </summary>
@@ -42,9 +44,11 @@ namespace PokemonGo.RocketAPI.Login
 
         static PtcLogin()
         {
+            Cookies = new CookieContainer();
             HttpClient = new HttpClient(
                 new HttpClientHandler
                 {
+                    CookieContainer = Cookies,
                     AutomaticDecompression = DecompressionMethods.GZip,
                     AllowAutoRedirect = false
                 }
@@ -73,11 +77,17 @@ namespace PokemonGo.RocketAPI.Login
         /// <returns></returns>
         public async Task<AccessToken> GetAccessToken()
         {
-                // robertmclaws: Should we be setting every UserAgent property like the other requests?
-                var loginData = await GetLoginParameters().ConfigureAwait(false);
-                var authTicket = await GetAuthenticationTicket(loginData).ConfigureAwait(false);
-                var accessToken = await GetOAuthToken(authTicket).ConfigureAwait(false);
-                return accessToken;
+            AccessToken accessToken;
+            PtcLoginParameters loginData = null;
+            var cookies = Cookies.GetCookies(new Uri("https://sso.pokemon.com"));
+            if (cookies.Count == 0)
+            {
+                loginData = await GetLoginParameters().ConfigureAwait(false);
+            }
+            var authTicket = await GetAuthenticationTicket(loginData).ConfigureAwait(false);
+            accessToken = await GetOAuthToken(authTicket).ConfigureAwait(false);
+
+            return accessToken;
         }
 
         #endregion
@@ -105,7 +115,11 @@ namespace PokemonGo.RocketAPI.Login
         /// <returns></returns>
         private async Task<string> GetAuthenticationTicket(PtcLoginParameters loginData)
         {
-            var requestData = new Dictionary<string, string>
+            HttpResponseMessage responseMessage;
+
+            if (loginData != null)
+            {
+                var requestData = new Dictionary<string, string>
                 {
                     {"lt", loginData.Lt},
                     {"execution", loginData.Execution},
@@ -113,16 +127,23 @@ namespace PokemonGo.RocketAPI.Login
                     {"username", Username},
                     {"password", Password}
                 };
-
-            var responseMessage = await HttpClient.PostAsync(Constants.LoginUrl, new FormUrlEncodedContent(requestData)).ConfigureAwait(false);
+                responseMessage = await HttpClient.PostAsync(Constants.LoginUrl, new FormUrlEncodedContent(requestData)).ConfigureAwait(false);
+            }
+            else
+            {
+                responseMessage = await HttpClient.GetAsync(Constants.LoginUrl);
+            }
 
             // robertmclaws: No need to even read the string if we have results from the location query.
-            if (responseMessage.Headers.Location != null)
+            if (responseMessage.StatusCode == HttpStatusCode.Found && responseMessage.Headers.Location != null)
             {
                 var decoder = new WwwFormUrlDecoder(responseMessage.Headers.Location.Query);
                 if (decoder.Count == 0)
                 {
-                    if (Debugger.IsAttached) Debugger.Break();
+                    if (Debugger.IsAttached)
+                    {
+                        Debugger.Break();
+                    }
                     throw new LoginFailedException();
                 }
                 return decoder.GetFirstValueByName("ticket");

--- a/PokemonGoAPI/Login/PtcLogin.cs
+++ b/PokemonGoAPI/Login/PtcLogin.cs
@@ -79,8 +79,10 @@ namespace PokemonGo.RocketAPI.Login
         {
             AccessToken accessToken;
             PtcLoginParameters loginData = null;
-            var cookies = Cookies.GetCookies(new Uri("https://sso.pokemon.com"));
-            if (cookies.Count == 0)
+            var cookies = Cookies.GetCookies("sso.pokemon.com").ToList();
+            // @robertmclaws: "CASTGC" is the name of the login cookie that the service looks for, afaik.
+            //                The second one is listed as a backup in case they change the cookie name.
+            if (!cookies.Any(c => c.Name == "CASTGC") || cookies.Count == 0)
             {
                 loginData = await GetLoginParameters().ConfigureAwait(false);
             }

--- a/PokemonGoAPI/PokemonGoAPI.csproj
+++ b/PokemonGoAPI/PokemonGoAPI.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Exceptions\InvalidResponseException.cs" />
     <Compile Include="Exceptions\LoginFailedException.cs" />
     <Compile Include="Exceptions\PTCOfflineException.cs" />
+    <Compile Include="Extensions\CookieContainerExtensions.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Helpers\Crypt.cs" />
     <Compile Include="Helpers\IDeviceInfos.cs" />

--- a/PokemonGoAPI/project.json
+++ b/PokemonGoAPI/project.json
@@ -5,7 +5,9 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Newtonsoft.Json": "9.0.1",
     "PCLWebUtility": "1.0.3",
-    "S2Geometry": "1.0.3"
+    "S2Geometry": "1.0.3",
+    "System.Collections.NonGeneric": "4.0.1",
+    "System.Reflection.TypeExtensions": "4.1.0"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
## Problem:
Problem arose due to changing HttpClient to static. Because getting the login parameters and Posting the login parameters to get the "ticket" hits the same URL, and we're using the same HttpClient instance, subsequent requests contain the auth "cookie". If you do a GET to that url with a valid AuthCookie, it updates the "ticket" needed to get the OAuthToken.

## Solution
Allow login request 2 of 3 to accept null parameters, and do a GET instead of a POST if the parameter is null.

STATUS: Awaiting final testing