### PR TITLE
Update French translation 

### DIFF
--- a/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fr.xlf
+++ b/PokemonGo-UWP/MultilingualResources/PokemonGo-UWP.fr.xlf
@@ -781,7 +781,7 @@ Tu as aussi reçu {1} Poudre d'étoile, {2} Bonbon et {3} XP.</target>
         </trans-unit>
         <trans-unit id="TimesTextBlock.Text" translate="yes" xml:space="preserve">
           <source>times</source>
-          <target state="translated">Temps</target>
+          <target state="translated">Fois</target>
         </trans-unit>
         <trans-unit id="EggDetailButtonTextBlock.Text" translate="yes" xml:space="preserve">
           <source>START INCUBATION</source>
@@ -793,7 +793,7 @@ Tu as aussi reçu {1} Poudre d'étoile, {2} Bonbon et {3} XP.</target>
         </trans-unit>
         <trans-unit id="TransferTextBlock.Text" translate="yes" xml:space="preserve">
           <source>TRANSFER</source>
-          <target state="translated">TRANSFERER</target>
+          <target state="translated">TRANSFÉRER</target>
         </trans-unit>
         <trans-unit id="SettingsLanguageRestartTextBlock.Text" translate="yes" xml:space="preserve">
           <source>You must restart the App to take effect.</source>
@@ -813,11 +813,11 @@ Tu as aussi reçu {1} Poudre d'étoile, {2} Bonbon et {3} XP.</target>
         </trans-unit>
         <trans-unit id="FavoriteTextBlock.Text" translate="yes" xml:space="preserve">
           <source>FAVORITE</source>
-          <target state="translated">FAVORI</target>
+          <target state="translated">FAVORIS</target>
         </trans-unit>
         <trans-unit id="AppraiseTextBlock.Text" translate="yes" xml:space="preserve">
           <source>APPRAISE</source>
-          <target state="new">APPRAISE</target>
+          <target state="new">ÉVALUER</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Capslock</note>
         </trans-unit>
         <trans-unit id="AwardedExperienceTextBlock.Text" translate="yes" xml:space="preserve">


### PR DESCRIPTION

Changes
-------
Temps -> fois
Appraise -> évaluer
Transferer -> transférer
favori -> favoris

Change details
--------------
Times must be translate "fois" and not "temps"
Here we want to know the number of time w've seen and caught a pokemon, not the time we spend catching it. "Nombre de fois" et non le "temps passé"

Appraise was not translated and the official translation is "évaluer"

Transférer takes an accent.

Favorite is plural in french version, so I added a S at the end.