### PR TITLE
Grammar/context for restart text (minor)

### DIFF
--- a/PokemonGo-UWP/Strings/en-US/Resources.resw
+++ b/PokemonGo-UWP/Strings/en-US/Resources.resw
@@ -285,7 +285,7 @@
     <value>times</value>
   </data>
   <data name="SettingsLanguageRestartTextBlock.Text" xml:space="preserve">
-    <value>You must restart the App to take effect.</value>
+    <value>You must restart the App for language changes to take effect.</value>
   </data>
   <data name="SettingsLanguageTextBlock.Text" xml:space="preserve">
     <value>Language</value>


### PR DESCRIPTION
Closes issues
-------------

Changes
-------
- Restart text string (en-US)

Change details
--------------
Previous wording ("restart to take effect") was both unclear and grammatically incorrect

Other informations
------------------


