### PR TITLE
Fixed music

### DIFF
--- a/PokemonGo-UWP/Utils/Helpers/AudioUtils.cs
+++ b/PokemonGo-UWP/Utils/Helpers/AudioUtils.cs
@@ -21,9 +21,9 @@ namespace PokemonGo_UWP.Utils
 
         #region Media Elements
         
-        //private static readonly MediaPlayer GameplaySound = new MediaPlayer();
-        //private static readonly MediaPlayer EncounterSound = new MediaPlayer();
-        //private static readonly MediaPlayer PokemonFoundSound = new MediaPlayer();
+        private static readonly MediaPlayer GameplaySound = new MediaPlayer();
+        private static readonly MediaPlayer EncounterSound = new MediaPlayer();
+        private static readonly MediaPlayer PokemonFoundSound = new MediaPlayer();
         
         #endregion       
 
@@ -34,13 +34,13 @@ namespace PokemonGo_UWP.Utils
         static AudioUtils()
         {                        
             //// Get files and create elements   
-            //GameplaySound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{GAMEPLAY}"));
-            //EncounterSound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{ENCOUNTER_POKEMON}"));
-            //PokemonFoundSound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{POKEMON_FOUND_DING}"));
+            GameplaySound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{GAMEPLAY}"));
+            EncounterSound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{ENCOUNTER_POKEMON}"));
+            PokemonFoundSound.Source = MediaSource.CreateFromUri(new Uri($"ms-appx:///Assets/Audio/{POKEMON_FOUND_DING}"));
             //// Set mode and volume
-            //GameplaySound.AudioCategory = EncounterSound.AudioCategory = PokemonFoundSound.AudioCategory = MediaPlayerAudioCategory.GameMedia;
-            //GameplaySound.IsLoopingEnabled = true;
-            //ToggleSounds();
+            GameplaySound.AudioCategory = EncounterSound.AudioCategory = PokemonFoundSound.AudioCategory = MediaPlayerAudioCategory.GameMedia;
+            GameplaySound.IsLoopingEnabled = true;
+            ToggleSounds();
             
         }
 
@@ -49,8 +49,8 @@ namespace PokemonGo_UWP.Utils
         /// </summary>
         public static void ToggleSounds()
         {                      
-            //GameplaySound.IsMuted =
-            //    EncounterSound.IsMuted = PokemonFoundSound.IsMuted = !SettingsService.Instance.IsMusicEnabled;
+            GameplaySound.IsMuted =
+                EncounterSound.IsMuted = PokemonFoundSound.IsMuted = !SettingsService.Instance.IsMusicEnabled;
                 
         }
 
@@ -60,22 +60,22 @@ namespace PokemonGo_UWP.Utils
         /// <param name="asset"></param>
         /// <returns></returns>
         public static void PlaySound(string asset)
-        {            
-            //switch (asset)
-            //{
-            //    case GAMEPLAY:
-            //        if (GameplaySound.PlaybackSession.PlaybackState != MediaPlaybackState.Playing)
-            //            GameplaySound.Play();
-            //        StopSound(ENCOUNTER_POKEMON);                  
-            //        break;
-            //    case ENCOUNTER_POKEMON:
-            //        GameplaySound.Pause();
-            //        EncounterSound.Play();
-            //        break;
-            //    case POKEMON_FOUND_DING:
-            //        PokemonFoundSound.Play();
-            //        break;
-            //}            
+        {
+            switch (asset)
+            {
+                case GAMEPLAY:
+                    if (GameplaySound.PlaybackSession.PlaybackState != MediaPlaybackState.Playing)
+                        GameplaySound.Play();
+                    StopSound(ENCOUNTER_POKEMON);
+                    break;
+                case ENCOUNTER_POKEMON:
+                    GameplaySound.Pause();
+                    EncounterSound.Play();
+                    break;
+                case POKEMON_FOUND_DING:
+                    PokemonFoundSound.Play();
+                    break;
+            }
         }
 
         /// <summary>
@@ -84,35 +84,35 @@ namespace PokemonGo_UWP.Utils
         /// <param name="asset"></param>
         /// <returns></returns>
         public static void StopSound(string asset)
-        {            
-            //switch (asset)
-            //{
-            //    case GAMEPLAY:
-            //        GameplaySound.Pause();
-            //        GameplaySound.PlaybackSession.Position = TimeSpan.Zero;
-            //        break;
-            //    case ENCOUNTER_POKEMON:
-            //        EncounterSound.Pause();
-            //        EncounterSound.PlaybackSession.Position = TimeSpan.Zero;
-            //        break;
-            //    case POKEMON_FOUND_DING:
-            //        PokemonFoundSound.Pause();
-            //        PokemonFoundSound.PlaybackSession.Position = TimeSpan.Zero;
-            //        break;
-            //}            
+        {
+            switch (asset)
+            {
+                case GAMEPLAY:
+                    GameplaySound.Pause();
+                    GameplaySound.PlaybackSession.Position = TimeSpan.Zero;
+                    break;
+                case ENCOUNTER_POKEMON:
+                    EncounterSound.Pause();
+                    EncounterSound.PlaybackSession.Position = TimeSpan.Zero;
+                    break;
+                case POKEMON_FOUND_DING:
+                    PokemonFoundSound.Pause();
+                    PokemonFoundSound.PlaybackSession.Position = TimeSpan.Zero;
+                    break;
+            }
         }
 
         /// <summary>
         /// Stops all playing sounds
         /// </summary>
         public static void StopSounds()
-        {            
-            //GameplaySound.Pause();
-            //GameplaySound.PlaybackSession.Position = TimeSpan.Zero;
-            //EncounterSound.Pause();
-            //EncounterSound.PlaybackSession.Position = TimeSpan.Zero;
-            //PokemonFoundSound.Pause();
-            //PokemonFoundSound.PlaybackSession.Position = TimeSpan.Zero;            
+        {
+            GameplaySound.Pause();
+            GameplaySound.PlaybackSession.Position = TimeSpan.Zero;
+            EncounterSound.Pause();
+            EncounterSound.PlaybackSession.Position = TimeSpan.Zero;
+            PokemonFoundSound.Pause();
+            PokemonFoundSound.PlaybackSession.Position = TimeSpan.Zero;
         }
     }
 }

--- a/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
+++ b/PokemonGo-UWP/Views/CapturePokemonPage.xaml.cs
@@ -205,6 +205,7 @@ namespace PokemonGo_UWP.Views
         {
             base.OnNavigatingFrom(e);
             UnsubscribeToCaptureEvents();
+            AudioUtils.PlaySound(AudioUtils.GAMEPLAY);
         }
 
         #endregion


### PR DESCRIPTION
Closes issues
-------------
- Closes #1854 
- Closes #1852 

Changes
-------
- Uncommented the music code
- When pokemon encounter page is closed, the gameplay music starts again

Other informations
------------------
The music was available before, but commented out. I tried to find out why, but could not find it.
Only thing I changed besides of putting the commented lines back is, is when the pokemon encounter page closes, the normal gameplay music is started again.