### PR TITLE
Fixed EggOverview page

### DIFF
--- a/PokemonGo-UWP/Views/Pokemon/EggInventoryControl.xaml
+++ b/PokemonGo-UWP/Views/Pokemon/EggInventoryControl.xaml
@@ -146,8 +146,11 @@
                         <TextBlock Grid.Row="2"
                                    HorizontalAlignment="Center"
                                    FontFamily="{StaticResource LatoBoldFont}"
-                                   FontSize="15"
-                                   Foreground="{StaticResource TitleTextColor}"><Run Text="{x:Bind EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.0\}}" /><Run Text="/" /><Run Text="{x:Bind EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.0\}}" />
+                                   FontSize="13"
+                                   Foreground="{StaticResource TitleTextColor}">
+                            <Run Text="{Binding EggKmWalkedStart, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.##\}}" />
+                            <Run Text="/" />
+                            <Run Text="{x:Bind EggKmWalkedTarget, Converter={StaticResource StringFormatConverter}, ConverterParameter=\{0:0.0\}}" />
                             <Run FontFamily="{StaticResource LatoMediumFont}"
                                  FontSize="11"
                                  Foreground="{StaticResource GrayTextColor}"


### PR DESCRIPTION
Closes issues
-------------
- Closes #1839 

Changes
-------
- The egg overview page now shows the walked distance in stead of 0/xx km

Change details
--------------
To see the change: go to pokeball menu -> pokémon -> eggs
The incubated eggs show the walked distance, just like on the details page, in stead of 0.00 / x,00 km

Other informations
------------------
Slightly resized the font to show distances for 10 km eggs.